### PR TITLE
Added support for Riviera-Pro under Linux

### DIFF
--- a/RunAllTests.pro
+++ b/RunAllTests.pro
@@ -49,6 +49,10 @@ include ./testbench/TestCases_Interrupt
 include  ./testbench/TbAxi4_ReadPoll
 include  ./testbench/TbAxi4_ReadPoll/tests.pro
 
+# Analyze Axi4 testbench and run tests on it
+include  ./testbench/TbAxi4_Responder
+include  ./testbench/TbAxi4_Responder/tests.pro
+
 # Analyze Ethernet testbench and run tests on it
 include ./testbench/TbEthernet
 include ./testbench/TestCases_Ethernet

--- a/RunAllTests.pro
+++ b/RunAllTests.pro
@@ -45,6 +45,10 @@ include  ./testbench/TestCases
 include ./testbench/TbAxi4_Interrupt
 include ./testbench/TestCases_Interrupt
 
+# Analyze Axi4 testbench and run tests on it
+include  ./testbench/TbAxi4_ReadPoll
+include  ./testbench/TbAxi4_ReadPoll/tests.pro
+
 # Analyze Ethernet testbench and run tests on it
 include ./testbench/TbEthernet
 include ./testbench/TestCases_Ethernet

--- a/RunAllTests.pro
+++ b/RunAllTests.pro
@@ -53,6 +53,10 @@ include  ./testbench/TbAxi4_ReadPoll/tests.pro
 include  ./testbench/TbAxi4_Responder
 include  ./testbench/TbAxi4_Responder/tests.pro
 
+# Analyze DpRam testbench and run tests on it
+include  ./testbench/TbDpRam
+include  ./testbench/TbDpRam/tests.pro
+
 # Analyze Ethernet testbench and run tests on it
 include ./testbench/TbEthernet
 include ./testbench/TestCases_Ethernet

--- a/Scripts/MakeVproc.tcl
+++ b/Scripts/MakeVproc.tcl
@@ -96,7 +96,7 @@ proc mk_vproc_common {testname libname} {
     }
     
     # Ensure the correct path to the ALDEC tools
-    set aldecpath [file normalize $::env(_)/../..]
+    set aldecpath [file normalize [info nameofexecutable]/../..]
     set vendorflags "ALDECDIR=${aldecpath}"
   }
 

--- a/Scripts/MakeVproc.tcl
+++ b/Scripts/MakeVproc.tcl
@@ -80,7 +80,8 @@ proc gen_lib_flags {libname} {
 
 proc mk_vproc_common {testname libname} {
 
-# Get the OS that we are running on
+  # Get the OS that we are running on
+  set osname $::osvvm::OperatingSystemName
 
   # Default of no additional vendor specific flags
   set vendorflags "DUMMY="
@@ -96,7 +97,12 @@ proc mk_vproc_common {testname libname} {
     }
     
     # Ensure the correct path to the ALDEC tools
-    set aldecpath [file normalize [info nameofexecutable]/../..]
+    if {"$osname" eq "linux"} {
+      set aldecpath [file normalize [info nameofexecutable]/../../..]
+    } else {
+      set aldecpath [file normalize [info nameofexecutable]/../..]
+    }
+    
     set vendorflags "ALDECDIR=${aldecpath}"
   }
 

--- a/Scripts/client_gui.py
+++ b/Scripts/client_gui.py
@@ -79,6 +79,7 @@ import time
 import socket
 import platform
 import os
+import sys
 
 from tkinter            import *
 from tkinter.ttk        import *

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -48,6 +48,8 @@
 class OsvvmCosim
 {
 public:
+                const int max_data_buf_size = DATABUF_SIZE;
+
                 OsvvmCosim      (int nodeIn = 0, std::string test_name = "") : node(nodeIn) {
                    if (test_name.compare(""))
                    {
@@ -197,6 +199,15 @@ public:
       void     transBurstCheckIncrement      (      uint8_t  data, const int bytesize)                                     {VTransCheckBurstIncrement(&data, bytesize, node);}
       void     transBurstCheckRandom         (      uint8_t  data, const int bytesize)                                     {VTransCheckBurstRandom   (&data, bytesize, node);}
 
+      bool     transBurstCheckData           (      uint8_t *expdata, const int bytesize)
+                                             {uint8_t buf[max_data_buf_size]; transBurstPopData(buf, bytesize); return cmpBuffers(buf, expdata, bytesize);}
+
+      bool     transBurstReadCheckData       (const uint32_t addr, uint8_t *expdata, const int bytesize, const int prot = 0)
+                                             {uint8_t buf[max_data_buf_size]; transBurstRead(addr, buf, bytesize, prot); return cmpBuffers(buf, expdata, bytesize);}
+
+      bool     transBurstReadCheckData       (const uint64_t addr, uint8_t *expdata, const int bytesize, const int prot = 0)
+                                             {uint8_t buf[max_data_buf_size]; transBurstRead(addr, buf, bytesize, prot); return cmpBuffers(buf, expdata, bytesize);}
+
       void     regInterruptCB                (pVUserInt_t func)                                                            {VRegInterrupt(func, node);}
 
       void     waitForSim                    (void)                                                                        {VWaitForSim(node);}
@@ -204,6 +215,8 @@ public:
       int      getNodeNumber                 (void)                                                                        {return node;}
 
 private:
+
+      bool     cmpBuffers                    (const uint8_t *got, const uint8_t *exp, const int bytesize) {for (int i=0; i < bytesize;i++) if (got[i] != exp[i]) return true; return false;}
 
       int      node;
 };

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -166,6 +166,8 @@ public:
 
       void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWrite(addr, data, bytesize, prot, node);}
       void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWrite(addr, data, bytesize, prot, node);}
+      void     transBurstWrite               (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstWrite(addr, bytesize, prot, node);}
+      void     transBurstWrite               (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstWrite(addr, bytesize, prot, node);}
       void     transBurstWriteAsync          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
       void     transBurstWriteAsync          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
 
@@ -178,15 +180,19 @@ public:
       void     transBurstWriteRandomAsync    (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
       void     transBurstWriteRandomAsync    (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
 
-      void     transBurstPushIncrement       (       uint8_t data, const int bytesize)                                     {VTransBurstPushIncrement(&data, bytesize, node);}
-      void     transBurstPushRandom          (       uint8_t data, const int bytesize)                                     {VTransBurstPushRandom(&data, bytesize, node);}
+      void     transBurstPushData            (      uint8_t *data, const int bytesize)                                     {VTransBurstPushData(data, bytesize, node);}
+      void     transBurstPushIncrement       (      uint8_t  data, const int bytesize)                                     {VTransBurstPushIncrement(&data, bytesize, node);}
+      void     transBurstPushRandom          (      uint8_t  data, const int bytesize)                                     {VTransBurstPushRandom(&data, bytesize, node);}
 
       void     transBurstRead                (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstRead (addr, data, bytesize, prot, node);}
       void     transBurstRead                (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstRead (addr, data, bytesize, prot, node);}
+      void     transBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstRead (addr, bytesize, prot, node);}
+      void     transBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstRead (addr, bytesize, prot, node);}
       void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadIncrement(addr, &data, bytesize, prot, node);}
       void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadIncrement(addr, &data, bytesize, prot, node);}
       void     transBurstReadCheckRandom     (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadRandom(addr, &data, bytesize, prot, node);}
       void     transBurstReadCheckRandom     (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadRandom(addr, &data, bytesize, prot, node);}
+      void     transBurstPopData             (uint8_t  *data, const int bytesize)                                          {VTransBurstPopData(data, bytesize, node);}
 
       void     transBurstCheckIncrement      (      uint8_t  data, const int bytesize)                                     {VTransCheckBurstIncrement(&data, bytesize, node);}
       void     transBurstCheckRandom         (      uint8_t  data, const int bytesize)                                     {VTransCheckBurstRandom   (&data, bytesize, node);}

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -15,12 +15,14 @@
 //
 //  Revision History:
 //    Date      Version    Description
-//    11/2022   2023.01    Initial revision
+//    05/2023   2023.05    Adding asynchronous transaction support
+//    03/2023   2023.04    Adding basic stream support
+//    01/2023   2023.01    Initial revision
 //
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -62,32 +64,70 @@ public:
 #endif
       }
 
-      uint8_t  transWrite      (const uint32_t addr, const uint8_t  data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint16_t transWrite      (const uint32_t addr, const uint16_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint32_t transWrite      (const uint32_t addr, const uint32_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint8_t  transWrite      (const uint64_t addr, const uint8_t  data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint16_t transWrite      (const uint64_t addr, const uint16_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint32_t transWrite      (const uint64_t addr, const uint32_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint64_t transWrite      (const uint64_t addr, const uint64_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-                               
-      void     transRead       (const uint32_t addr, uint8_t  *data,      const int prot = 0) {VTransRead(addr, data, prot, node);}
-      void     transRead       (const uint32_t addr, uint16_t *data,      const int prot = 0) {VTransRead(addr, data, prot, node);}
-      void     transRead       (const uint32_t addr, uint32_t *data,      const int prot = 0) {VTransRead(addr, data, prot, node);}
-      void     transRead       (const uint64_t addr, uint8_t  *data,      const int prot = 0) {VTransRead(addr, data, prot, node);}
-      void     transRead       (const uint64_t addr, uint16_t *data,      const int prot = 0) {VTransRead(addr, data, prot, node);}
-      void     transRead       (const uint64_t addr, uint32_t *data,      const int prot = 0) {VTransRead(addr, data, prot, node);}
-      void     transRead       (const uint64_t addr, uint64_t *data,      const int prot = 0) {VTransRead(addr, data, prot, node);}
+      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
+      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
+      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
+      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
+      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
+      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
+      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
+      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
+      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
+      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
+      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
+      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
+      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
+      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
 
-      void     transBurstWrite (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWrite(addr, data, bytesize, prot, node);}
-      void     transBurstWrite (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWrite(addr, data, bytesize, prot, node);}
-      void     transBurstRead  (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstRead (addr, data, bytesize, prot, node);}
-      void     transBurstRead  (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstRead (addr, data, bytesize, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
 
-      void     regInterruptCB  (pVUserInt_t func)                                             {VRegInterrupt(func, node);}
-      
-      void     waitForSim      (void)                                                         {VWaitForSim(node);}
+      void     transWriteAddressAsync (const uint32_t addr)                                          {VTransWriteAddressAsync(addr, node);}
+      void     transWriteAddressAsync (const uint64_t addr)                                          {VTransWriteAddressAsync(addr, node);}
+      void     transWriteDataAsync    (const uint8_t  data, uint32_t bytelane = 0)                   {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync    (const uint16_t data, uint32_t bytelane = 0)                   {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync    (const uint32_t data, uint32_t bytelane = 0)                   {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync    (const uint64_t data, uint32_t bytelane = 0)                   {VTransWriteDataAsync(data, bytelane, node);}
 
-      int      getNodeNumber   () {return node;}
+      void     transReadAddressAsync  (const uint32_t addr)                                          {VTransReadAddressAsync(addr, node);}
+      void     transReadAddressAsync  (const uint64_t addr)                                          {VTransReadAddressAsync(addr, node);}
+      void     transReadData          (uint8_t       *data, const int prot = 0)                      {VTransReadData(data, node);}
+      void     transReadData          (uint16_t      *data, const int prot = 0)                      {VTransReadData(data, node);}
+      void     transReadData          (uint32_t      *data, const int prot = 0)                      {VTransReadData(data, node);}
+      void     transReadData          (uint64_t      *data, const int prot = 0)                      {VTransReadData(data, node);}
+
+      void     transRead              (const uint32_t addr, uint8_t  *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
+      void     transRead              (const uint32_t addr, uint16_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
+      void     transRead              (const uint32_t addr, uint32_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
+      void     transRead              (const uint64_t addr, uint8_t  *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
+      void     transRead              (const uint64_t addr, uint16_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
+      void     transRead              (const uint64_t addr, uint32_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
+      void     transRead              (const uint64_t addr, uint64_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
+
+      void     transBurstWrite        (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWrite(addr, data, bytesize, prot, node);}
+      void     transBurstWrite        (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWrite(addr, data, bytesize, prot, node);}
+      void     transBurstWriteAsync   (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
+      void     transBurstWriteAsync   (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
+      void     transBurstRead         (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstRead (addr, data, bytesize, prot, node);}
+      void     transBurstRead         (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstRead (addr, data, bytesize, prot, node);}
+
+      void     regInterruptCB         (pVUserInt_t func) {VRegInterrupt(func, node);}
+
+      void     waitForSim             (void)             {VWaitForSim(node);}
+
+      int      getNodeNumber          (void)             {return node;}
 
 private:
 

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -90,13 +90,13 @@ public:
       void     transWriteAndRead      (uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
       void     transWriteAndRead      (uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
 
-      void     transWriteAndReadAsync (uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
-      void     transWriteAndReadAsync (uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
-      void     transWriteAndReadAsync (uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
-      void     transWriteAndReadAsync (uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
-      void     transWriteAndReadAsync (uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
-      void     transWriteAndReadAsync (uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
-      void     transWriteAndReadAsync (uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint32_t addr, const uint8_t  wdata, const int prot = 0)                  {VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint32_t addr, const uint16_t wdata, const int prot = 0)                  {VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint32_t addr, const uint32_t wdata, const int prot = 0)                  {VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint64_t addr, const uint8_t  wdata, const int prot = 0)                  {VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint64_t addr, const uint16_t wdata, const int prot = 0)                  {VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint64_t addr, const uint32_t wdata, const int prot = 0)                  {VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint64_t addr, const uint64_t wdata, const int prot = 0)                  {VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
 
       void     transWriteAddressAsync        (uint32_t addr, const int prot = 0)                                 {VTransUserCommon(ASYNC_WRITE_ADDRESS, &addr, (uint32_t)0, &dummyStatus, prot, node);}
       void     transWriteAddressAsync        (uint64_t addr, const int prot = 0)                                 {VTransUserCommon(ASYNC_WRITE_ADDRESS, &addr, (uint32_t)0, &dummyStatus, prot, node);}

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -211,8 +211,8 @@ public:
                                              {uint8_t buf[max_data_buf_size]; transBurstRead(addr, buf, bytesize, prot); return cmpBuffers(buf, expdata, bytesize);}
                                              
       void     transWaitForTransaction       (void)                                                                        {VTransTransactionWait(WAIT_FOR_TRANSACTION, node);}
-      void     transWaitWriteForTransaction  (void)                                                                        {VTransTransactionWait(WAIT_FOR_WRITE_TRANSACTION, node);}
-      void     transWaitReadForTransaction   (void)                                                                        {VTransTransactionWait(WAIT_FOR_READ_TRANSACTION, node);}
+      void     transWaitForWriteTransaction  (void)                                                                        {VTransTransactionWait(WAIT_FOR_WRITE_TRANSACTION, node);}
+      void     transWaitForReadTransaction   (void)                                                                        {VTransTransactionWait(WAIT_FOR_READ_TRANSACTION, node);}
       int      transGetTransactionCount      (void)                                                                        {return VTransGetCount(GET_TRANSACTION_COUNT, node);}
       int      transGetWriteTransactionCount (void)                                                                        {return VTransGetCount(GET_WRITE_TRANSACTION_COUNT, node);}
       int      transGetReadTransactionCount  (void)                                                                        {return VTransGetCount(GET_READ_TRANSACTION_COUNT, node);}

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -64,98 +64,122 @@ public:
 #endif
       }
 
-      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
-      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
-      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
-      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
-      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
-      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
-      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
+      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
+      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
+      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
+      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
+      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
+      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
+      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
 
-      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
-      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
-      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
-      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
-      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
-      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
-      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
+      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
+      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
+      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
+      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
+      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
+      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
+      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
 
-      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
 
-      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
 
-      void     transWriteAddressAsync        (const uint32_t addr)                                                       {VTransWriteAddressAsync(addr, node);}
-      void     transWriteAddressAsync        (const uint64_t addr)                                                       {VTransWriteAddressAsync(addr, node);}
+      void     transWriteAddressAsync        (const uint32_t addr)                                                         {VTransWriteAddressAsync(addr, node);}
+      void     transWriteAddressAsync        (const uint64_t addr)                                                         {VTransWriteAddressAsync(addr, node);}
 
-      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                  {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                  {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                  {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                  {VTransWriteDataAsync(data, bytelane, node);}
 
-      void     transReadAddressAsync         (const uint32_t addr)                                                       {VTransReadAddressAsync(addr, node);}
-      void     transReadAddressAsync         (const uint64_t addr)                                                       {VTransReadAddressAsync(addr, node);}
+      void     transReadAddressAsync         (const uint32_t addr)                                                         {VTransReadAddressAsync(addr, node);}
+      void     transReadAddressAsync         (const uint64_t addr)                                                         {VTransReadAddressAsync(addr, node);}
 
-      void     transReadData                 (uint8_t       *data)                                                       {VTransReadData(data, node);}
-      void     transReadData                 (uint16_t      *data)                                                       {VTransReadData(data, node);}
-      void     transReadData                 (uint32_t      *data)                                                       {VTransReadData(data, node);}
-      void     transReadData                 (uint64_t      *data)                                                       {VTransReadData(data, node);}
+      void     transReadData                 (uint8_t       *data)                                                         {VTransReadData(data, node);}
+      void     transReadData                 (uint16_t      *data)                                                         {VTransReadData(data, node);}
+      void     transReadData                 (uint32_t      *data)                                                         {VTransReadData(data, node);}
+      void     transReadData                 (uint64_t      *data)                                                         {VTransReadData(data, node);}
 
-      bool     transTryReadData              (uint8_t       *data)                                                       {return VTransTryReadData(data, node);}
-      bool     transTryReadData              (uint16_t      *data)                                                       {return VTransTryReadData(data, node);}
-      bool     transTryReadData              (uint32_t      *data)                                                       {return VTransTryReadData(data, node);}
-      bool     transTryReadData              (uint64_t      *data)                                                       {return VTransTryReadData(data, node);}
+      bool     transTryReadData              (uint8_t       *data)                                                         {return VTransTryReadData(data, node);}
+      bool     transTryReadData              (uint16_t      *data)                                                         {return VTransTryReadData(data, node);}
+      bool     transTryReadData              (uint32_t      *data)                                                         {return VTransTryReadData(data, node);}
+      bool     transTryReadData              (uint64_t      *data)                                                         {return VTransTryReadData(data, node);}
 
-      void     transReadDataCheck            (uint8_t        data)                                                       {VTransReadCheckData(data, node);}
-      void     transReadDataCheck            (uint16_t       data)                                                       {VTransReadCheckData(data, node);}
-      void     transReadDataCheck            (uint32_t       data)                                                       {VTransReadCheckData(data, node);}
-      void     transReadDataCheck            (uint64_t       data)                                                       {VTransReadCheckData(data, node);}
+      void     transReadDataCheck            (uint8_t        data)                                                         {VTransReadCheckData(data, node);}
+      void     transReadDataCheck            (uint16_t       data)                                                         {VTransReadCheckData(data, node);}
+      void     transReadDataCheck            (uint32_t       data)                                                         {VTransReadCheckData(data, node);}
+      void     transReadDataCheck            (uint64_t       data)                                                         {VTransReadCheckData(data, node);}
 
-      bool     transTryReadDataCheck         (uint8_t        data)                                                       {return VTransTryReadCheckData(data, node);}
-      bool     transTryReadDataCheck         (uint16_t       data)                                                       {return VTransTryReadCheckData(data, node);}
-      bool     transTryReadDataCheck         (uint32_t       data)                                                       {return VTransTryReadCheckData(data, node);}
-      bool     transTryReadDataCheck         (uint64_t       data)                                                       {return VTransTryReadCheckData(data, node);}
+      bool     transTryReadDataCheck         (uint8_t        data)                                                         {return VTransTryReadCheckData(data, node);}
+      bool     transTryReadDataCheck         (uint16_t       data)                                                         {return VTransTryReadCheckData(data, node);}
+      bool     transTryReadDataCheck         (uint32_t       data)                                                         {return VTransTryReadCheckData(data, node);}
+      bool     transTryReadDataCheck         (uint64_t       data)                                                         {return VTransTryReadCheckData(data, node);}
 
-      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
 
-      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
+      void     transReadPoll                 (const uint32_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+                                                 {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
+
+      void     transReadPoll                 (const uint32_t addr, uint16_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+                                                 {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
+
+      void     transReadPoll                 (const uint32_t addr, uint32_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+                                                 {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
+
+      void     transReadPoll                 (const uint64_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+                                                 {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
+
+      void     transReadPoll                 (const uint64_t addr, uint16_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+                                                 {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
+
+      void     transReadPoll                 (const uint64_t addr, uint32_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+                                                 {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
+
+      void     transReadPoll                 (const uint64_t addr, uint64_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+                                                 {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
+
+      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
 
       void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWrite(addr, data, bytesize, prot, node);}
       void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWrite(addr, data, bytesize, prot, node);}
       void     transBurstWriteAsync          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
       void     transBurstWriteAsync          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
 
-      void     transBurstWriteIncrement      (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteIncrement(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteIncrement      (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteIncrement(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteIncrementAsync (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteIncrementAsync(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteIncrementAsync (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteIncrementAsync(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteRandom         (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteRandom(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteRandom         (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteRandom(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteRandomAsync    (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteRandomAsync    (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrement      (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteIncrement(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrement      (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteIncrement(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrementAsync (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteIncrementAsync(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrementAsync (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteIncrementAsync(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandom         (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandom(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandom         (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandom(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandomAsync    (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandomAsync    (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
+
+      void     transBurstPushIncrement       (       uint8_t data, const int bytesize)                                     {VTransBurstPushIncrement(&data, bytesize, node);}
+      void     transBurstPushRandom          (       uint8_t data, const int bytesize)                                     {VTransBurstPushRandom(&data, bytesize, node);}
 
       void     transBurstRead                (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstRead (addr, data, bytesize, prot, node);}
       void     transBurstRead                (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstRead (addr, data, bytesize, prot, node);}
@@ -163,6 +187,9 @@ public:
       void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadIncrement(addr, &data, bytesize, prot, node);}
       void     transBurstReadCheckRandom     (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadRandom(addr, &data, bytesize, prot, node);}
       void     transBurstReadCheckRandom     (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadRandom(addr, &data, bytesize, prot, node);}
+
+      void     transBurstCheckIncrement      (      uint8_t  data, const int bytesize)                                     {VTransCheckBurstIncrement(&data, bytesize, node);}
+      void     transBurstCheckRandom         (      uint8_t  data, const int bytesize)                                     {VTransCheckBurstRandom   (&data, bytesize, node);}
 
       void     regInterruptCB                (pVUserInt_t func)                                                            {VRegInterrupt(func, node);}
 

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -66,105 +66,107 @@ public:
 #endif
       }
 
-      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint8_t  transWrite             (uint32_t addr, const uint8_t  data, const int prot = 0)                   {return VTransUserCommon(WRITE_OP, &addr, data, &dummyStatus, prot, node);}
+      uint16_t transWrite             (uint32_t addr, const uint16_t data, const int prot = 0)                   {return VTransUserCommon(WRITE_OP, &addr, data, &dummyStatus, prot, node);}
+      uint32_t transWrite             (uint32_t addr, const uint32_t data, const int prot = 0)                   {return VTransUserCommon(WRITE_OP, &addr, data, &dummyStatus, prot, node);}
+      uint8_t  transWrite             (uint64_t addr, const uint8_t  data, const int prot = 0)                   {return VTransUserCommon(WRITE_OP, &addr, data, &dummyStatus, prot, node);}
+      uint16_t transWrite             (uint64_t addr, const uint16_t data, const int prot = 0)                   {return VTransUserCommon(WRITE_OP, &addr, data, &dummyStatus, prot, node);}
+      uint32_t transWrite             (uint64_t addr, const uint32_t data, const int prot = 0)                   {return VTransUserCommon(WRITE_OP, &addr, data, &dummyStatus, prot, node);}
+      uint64_t transWrite             (uint64_t addr, const uint64_t data, const int prot = 0)                   {return VTransUserCommon(WRITE_OP, &addr, data, &dummyStatus, prot, node);}
 
-      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint8_t  transWriteAsync        (uint32_t addr, const uint8_t  data, const int prot = 0)                   {return VTransUserCommon(ASYNC_WRITE, &addr, data, &dummyStatus, prot, node);}
+      uint16_t transWriteAsync        (uint32_t addr, const uint16_t data, const int prot = 0)                   {return VTransUserCommon(ASYNC_WRITE, &addr, data, &dummyStatus, prot, node);}
+      uint32_t transWriteAsync        (uint32_t addr, const uint32_t data, const int prot = 0)                   {return VTransUserCommon(ASYNC_WRITE, &addr, data, &dummyStatus, prot, node);}
+      uint8_t  transWriteAsync        (uint64_t addr, const uint8_t  data, const int prot = 0)                   {return VTransUserCommon(ASYNC_WRITE, &addr, data, &dummyStatus, prot, node);}
+      uint16_t transWriteAsync        (uint64_t addr, const uint16_t data, const int prot = 0)                   {return VTransUserCommon(ASYNC_WRITE, &addr, data, &dummyStatus, prot, node);}
+      uint32_t transWriteAsync        (uint64_t addr, const uint32_t data, const int prot = 0)                   {return VTransUserCommon(ASYNC_WRITE, &addr, data, &dummyStatus, prot, node);}
+      uint64_t transWriteAsync        (uint64_t addr, const uint64_t data, const int prot = 0)                   {return VTransUserCommon(ASYNC_WRITE, &addr, data, &dummyStatus, prot, node);}
 
-      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndRead      (uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndRead      (uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndRead      (uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndRead      (uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndRead      (uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndRead      (uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
 
-      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
+      void     transWriteAndReadAsync (uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {*rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, &addr, wdata, &dummyStatus, prot, node);}
 
-      void     transWriteAddressAsync        (const uint32_t addr, const int prot = 0)                                     {int status; VTransUserCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, prot, node);}
-      void     transWriteAddressAsync        (const uint64_t addr, const int prot = 0)                                     {int status; VTransUserCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, prot, node);}
+      void     transWriteAddressAsync        (uint32_t addr, const int prot = 0)                                 {VTransUserCommon(ASYNC_WRITE_ADDRESS, &addr, (uint32_t)0, &dummyStatus, prot, node);}
+      void     transWriteAddressAsync        (uint64_t addr, const int prot = 0)                                 {VTransUserCommon(ASYNC_WRITE_ADDRESS, &addr, (uint32_t)0, &dummyStatus, prot, node);}
 
-      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                  {int status; VTransUserCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
-      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                  {int status; VTransUserCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
-      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                  {int status; VTransUserCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
-      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                  {int status; VTransUserCommon(ASYNC_WRITE_DATA, (uint64_t)bytelane, data, &status, 0, node);}
+      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                        {VTransUserCommon(ASYNC_WRITE_DATA, &bytelane, data, &dummyStatus, 0, node);}
+      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                        {VTransUserCommon(ASYNC_WRITE_DATA, &bytelane, data, &dummyStatus, 0, node);}
+      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                        {VTransUserCommon(ASYNC_WRITE_DATA, &bytelane, data, &dummyStatus, 0, node);}
+      void     transWriteDataAsync           (const uint64_t data, uint64_t bytelane = 0)                        {VTransUserCommon(ASYNC_WRITE_DATA, &bytelane, data, &dummyStatus, 0, node);}
 
-      void     transReadAddressAsync         (const uint32_t addr, const int prot = 0)                                     {int status; VTransUserCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, prot, node);}
-      void     transReadAddressAsync         (const uint64_t addr, const int prot = 0)                                     {int status; VTransUserCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, prot, node);}
+      void     transReadAddressAsync         (uint32_t addr, const int prot = 0)                                 {VTransUserCommon(ASYNC_READ_ADDRESS, &addr, (uint32_t)0, &dummyStatus, prot, node);}
+      void     transReadAddressAsync         (uint64_t addr, const int prot = 0)                                 {VTransUserCommon(ASYNC_READ_ADDRESS, &addr, (uint32_t)0, &dummyStatus, prot, node);}
 
-      void     transReadData                 (uint8_t       *data)                                                         {int status; *data = VTransUserCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
-      void     transReadData                 (uint16_t      *data)                                                         {int status; *data = VTransUserCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
-      void     transReadData                 (uint32_t      *data)                                                         {int status; *data = VTransUserCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
-      void     transReadData                 (uint64_t      *data)                                                         {int status; *data = VTransUserCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
+      void     transReadData                 (uint8_t       *data)                                               {*data = VTransUserCommon(READ_DATA, &dummyAddr32, (uint8_t)0, &dummyStatus, 0, node);}
+      void     transReadData                 (uint16_t      *data)                                               {*data = VTransUserCommon(READ_DATA, &dummyAddr32, (uint8_t)0, &dummyStatus, 0, node);}
+      void     transReadData                 (uint32_t      *data)                                               {*data = VTransUserCommon(READ_DATA, &dummyAddr32, (uint8_t)0, &dummyStatus, 0, node);}
+      void     transReadData                 (uint64_t      *data)                                               {*data = VTransUserCommon(READ_DATA, &dummyAddr64, (uint8_t)0, &dummyStatus, 0, node);}
 
-      bool     transTryReadData              (uint8_t       *data)                                                         {int status; *data = VTransUserCommon(ASYNC_READ_DATA, (uint32_t)0, (uint8_t) 0, &status, 0, node); return status;}
-      bool     transTryReadData              (uint16_t      *data)                                                         {int status; *data = VTransUserCommon(ASYNC_READ_DATA, (uint32_t)0, (uint16_t)0, &status, 0, node); return status;}
-      bool     transTryReadData              (uint32_t      *data)                                                         {int status; *data = VTransUserCommon(ASYNC_READ_DATA, (uint32_t)0, (uint32_t)0, &status, 0, node); return status;}
-      bool     transTryReadData              (uint64_t      *data)                                                         {int status; *data = VTransUserCommon(ASYNC_READ_DATA, (uint64_t)0, (uint64_t)0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint8_t       *data)                                               {int status; *data = VTransUserCommon(ASYNC_READ_DATA, &dummyAddr32, (uint8_t) 0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint16_t      *data)                                               {int status; *data = VTransUserCommon(ASYNC_READ_DATA, &dummyAddr32, (uint16_t)0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint32_t      *data)                                               {int status; *data = VTransUserCommon(ASYNC_READ_DATA, &dummyAddr32, (uint32_t)0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint64_t      *data)                                               {int status; *data = VTransUserCommon(ASYNC_READ_DATA, &dummyAddr64, (uint64_t)0, &status, 0, node); return status;}
 
-      void     transReadDataCheck            (uint8_t        data)                                                         {int status; VTransUserCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
-      void     transReadDataCheck            (uint16_t       data)                                                         {int status; VTransUserCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
-      void     transReadDataCheck            (uint32_t       data)                                                         {int status; VTransUserCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
-      void     transReadDataCheck            (uint64_t       data)                                                         {int status; VTransUserCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint8_t        data)                                               {VTransUserCommon(READ_DATA_CHECK, &dummyAddr32, data, &dummyStatus, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint16_t       data)                                               {VTransUserCommon(READ_DATA_CHECK, &dummyAddr32, data, &dummyStatus, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint32_t       data)                                               {VTransUserCommon(READ_DATA_CHECK, &dummyAddr32, data, &dummyStatus, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint64_t       data)                                               {VTransUserCommon(READ_DATA_CHECK, &dummyAddr64, data, &dummyStatus, (uint32_t)0, node);}
 
-      bool     transTryReadDataCheck         (uint8_t        data)                                                         {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
-      bool     transTryReadDataCheck         (uint16_t       data)                                                         {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
-      bool     transTryReadDataCheck         (uint32_t       data)                                                         {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
-      bool     transTryReadDataCheck         (uint64_t       data)                                                         {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint8_t        data)                                               {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, &dummyAddr32, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint16_t       data)                                               {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, &dummyAddr32, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint32_t       data)                                               {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, &dummyAddr32, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint64_t       data)                                               {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, &dummyAddr64, data, &status, (uint32_t)0, node); return status;}
 
-      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint8_t) 0, &status, prot, node);}
-      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint16_t)0, &status, prot, node);}
-      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint32_t)0, &status, prot, node);}
-      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint8_t) 0, &status, prot, node);}
-      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint16_t)0, &status, prot, node);}
-      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint32_t)0, &status, prot, node);}
-      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint64_t)0, &status, prot, node);}
+      void     transRead                     (uint32_t addr, uint8_t  *data, const int prot = 0)                 {*data = VTransUserCommon(READ_OP, &addr, (uint8_t) 0, &dummyStatus, prot, node);}
+      void     transRead                     (uint32_t addr, uint16_t *data, const int prot = 0)                 {*data = VTransUserCommon(READ_OP, &addr, (uint16_t)0, &dummyStatus, prot, node);}
+      void     transRead                     (uint32_t addr, uint32_t *data, const int prot = 0)                 {*data = VTransUserCommon(READ_OP, &addr, (uint32_t)0, &dummyStatus, prot, node);}
+      void     transRead                     (uint64_t addr, uint8_t  *data, const int prot = 0)                 {*data = VTransUserCommon(READ_OP, &addr, (uint8_t) 0, &dummyStatus, prot, node);}
+      void     transRead                     (uint64_t addr, uint16_t *data, const int prot = 0)                 {*data = VTransUserCommon(READ_OP, &addr, (uint16_t)0, &dummyStatus, prot, node);}
+      void     transRead                     (uint64_t addr, uint32_t *data, const int prot = 0)                 {*data = VTransUserCommon(READ_OP, &addr, (uint32_t)0, &dummyStatus, prot, node);}
+      void     transRead                     (uint64_t addr, uint64_t *data, const int prot = 0)                 {*data = VTransUserCommon(READ_OP, &addr, (uint64_t)0, &dummyStatus, prot, node);}
 
-      void     transReadPoll                 (const uint32_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+
+      void     transReadCheck                (uint32_t addr, uint8_t   data, const int prot = 0)                 {VTransUserCommon(READ_CHECK, &addr, data, &dummyStatus, prot, node);}
+      void     transReadCheck                (uint32_t addr, uint16_t  data, const int prot = 0)                 {VTransUserCommon(READ_CHECK, &addr, data, &dummyStatus, prot, node);}
+      void     transReadCheck                (uint32_t addr, uint32_t  data, const int prot = 0)                 {VTransUserCommon(READ_CHECK, &addr, data, &dummyStatus, prot, node);}
+      void     transReadCheck                (uint64_t addr, uint8_t   data, const int prot = 0)                 {VTransUserCommon(READ_CHECK, &addr, data, &dummyStatus, prot, node);}
+      void     transReadCheck                (uint64_t addr, uint16_t  data, const int prot = 0)                 {VTransUserCommon(READ_CHECK, &addr, data, &dummyStatus, prot, node);}
+      void     transReadCheck                (uint64_t addr, uint32_t  data, const int prot = 0)                 {VTransUserCommon(READ_CHECK, &addr, data, &dummyStatus, prot, node);}
+      void     transReadCheck                (uint64_t addr, uint64_t  data, const int prot = 0)                 {VTransUserCommon(READ_CHECK, &addr, data, &dummyStatus, prot, node);}
+
+
+      void     transReadPoll                 (uint32_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
 
-      void     transReadPoll                 (const uint32_t addr, uint16_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+      void     transReadPoll                 (uint32_t addr, uint16_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
 
-      void     transReadPoll                 (const uint32_t addr, uint32_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+      void     transReadPoll                 (uint32_t addr, uint32_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
 
-      void     transReadPoll                 (const uint64_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+      void     transReadPoll                 (uint64_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
 
-      void     transReadPoll                 (const uint64_t addr, uint16_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+      void     transReadPoll                 (uint64_t addr, uint16_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
 
-      void     transReadPoll                 (const uint64_t addr, uint32_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+      void     transReadPoll                 (uint64_t addr, uint32_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
 
-      void     transReadPoll                 (const uint64_t addr, uint64_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
+      void     transReadPoll                 (uint64_t addr, uint64_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
-
-      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
 
       void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
       void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
@@ -209,7 +211,7 @@ public:
 
       bool     transBurstReadCheckData       (const uint64_t addr, uint8_t *expdata, const int bytesize, const int prot = 0)
                                              {uint8_t buf[max_data_buf_size]; transBurstRead(addr, buf, bytesize, prot); return cmpBuffers(buf, expdata, bytesize);}
-                                             
+
       void     transWaitForTransaction       (void)                                                                        {VTransTransactionWait(WAIT_FOR_TRANSACTION, node);}
       void     transWaitForWriteTransaction  (void)                                                                        {VTransTransactionWait(WAIT_FOR_WRITE_TRANSACTION, node);}
       void     transWaitForReadTransaction   (void)                                                                        {VTransTransactionWait(WAIT_FOR_READ_TRANSACTION, node);}
@@ -226,6 +228,10 @@ public:
 private:
 
       bool     cmpBuffers                    (const uint8_t *got, const uint8_t *exp, const int bytesize) {for (int i=0; i < bytesize;i++) if (got[i] != exp[i]) return true; return false;}
+
+      int      dummyStatus;
+      uint32_t dummyAddr32;
+      uint64_t dummyAddr64;
 
       int      node;
 };

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -168,8 +168,8 @@ public:
 
       void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
       void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
-      void     transBurstWrite               (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(WRITE_BURST, BURST_TRANS, addr, null, bytesize, prot, node);}
-      void     transBurstWrite               (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(WRITE_BURST, BURST_TRANS, addr, null, bytesize, prot, node);}
+      void     transBurstWrite               (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(WRITE_BURST, BURST_TRANS, addr, NULL, bytesize, prot, node);}
+      void     transBurstWrite               (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(WRITE_BURST, BURST_TRANS, addr, NULL, bytesize, prot, node);}
       void     transBurstWriteAsync          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
       void     transBurstWriteAsync          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
 
@@ -188,8 +188,8 @@ public:
 
       void     transBurstRead                (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_NORM,  addr, data, bytesize, prot, node);}
       void     transBurstRead                (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_NORM,  addr, data, bytesize, prot, node);}
-      void     transBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(READ_BURST, BURST_TRANS, addr, null, bytesize, prot, node);}
-      void     transBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(READ_BURST, BURST_TRANS, addr, null, bytesize, prot, node);}
+      void     transBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(READ_BURST, BURST_TRANS, addr, NULL, bytesize, prot, node);}
+      void     transBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(READ_BURST, BURST_TRANS, addr, NULL, bytesize, prot, node);}
 
       void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_INCR, addr, &data, bytesize, prot, node);}
       void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_INCR, addr, &data, bytesize, prot, node);}
@@ -209,6 +209,13 @@ public:
 
       bool     transBurstReadCheckData       (const uint64_t addr, uint8_t *expdata, const int bytesize, const int prot = 0)
                                              {uint8_t buf[max_data_buf_size]; transBurstRead(addr, buf, bytesize, prot); return cmpBuffers(buf, expdata, bytesize);}
+                                             
+      void     transWaitForTransaction       (void)                                                                        {VTransTransactionWait(WAIT_FOR_TRANSACTION, node);}
+      void     transWaitWriteForTransaction  (void)                                                                        {VTransTransactionWait(WAIT_FOR_WRITE_TRANSACTION, node);}
+      void     transWaitReadForTransaction   (void)                                                                        {VTransTransactionWait(WAIT_FOR_READ_TRANSACTION, node);}
+      int      transGetTransactionCount      (void)                                                                        {return VTransGetCount(GET_TRANSACTION_COUNT, node);}
+      int      transGetWriteTransactionCount (void)                                                                        {return VTransGetCount(GET_WRITE_TRANSACTION_COUNT, node);}
+      int      transGetReadTransactionCount  (void)                                                                        {return VTransGetCount(GET_READ_TRANSACTION_COUNT, node);}
 
       void     regInterruptCB                (pVUserInt_t func)                                                            {VRegInterrupt(func, node);}
 

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -66,76 +66,76 @@ public:
 #endif
       }
 
-      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
-      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0)                       {int status; return VTransUserCommon(WRITE_OP, addr, data, &status, prot, node);}
 
-      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
-      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0)                       {int status; return VTransUserCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
 
-      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
 
-      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {int status; *rdata = VTransUserCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
 
-      void     transWriteAddressAsync        (const uint32_t addr)                                                         {int status; VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, 0, node);}
-      void     transWriteAddressAsync        (const uint64_t addr)                                                         {int status; VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, 0, node);}
+      void     transWriteAddressAsync        (const uint32_t addr, const int prot = 0)                                     {int status; VTransUserCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, prot, node);}
+      void     transWriteAddressAsync        (const uint64_t addr, const int prot = 0)                                     {int status; VTransUserCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, prot, node);}
 
-      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                  {int status; VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
-      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                  {int status; VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
-      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                  {int status; VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
-      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                  {int status; VTransCommon(ASYNC_WRITE_DATA, (uint64_t)bytelane, data, &status, 0, node);}
+      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                  {int status; VTransUserCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
+      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                  {int status; VTransUserCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
+      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                  {int status; VTransUserCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
+      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                  {int status; VTransUserCommon(ASYNC_WRITE_DATA, (uint64_t)bytelane, data, &status, 0, node);}
 
-      void     transReadAddressAsync         (const uint32_t addr)                                                         {int status; VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, 0, node);}
-      void     transReadAddressAsync         (const uint64_t addr)                                                         {int status; VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, 0, node);}
+      void     transReadAddressAsync         (const uint32_t addr, const int prot = 0)                                     {int status; VTransUserCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, prot, node);}
+      void     transReadAddressAsync         (const uint64_t addr, const int prot = 0)                                     {int status; VTransUserCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, prot, node);}
 
-      void     transReadData                 (uint8_t       *data)                                                         {int status; *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
-      void     transReadData                 (uint16_t      *data)                                                         {int status; *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
-      void     transReadData                 (uint32_t      *data)                                                         {int status; *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
-      void     transReadData                 (uint64_t      *data)                                                         {int status; *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
+      void     transReadData                 (uint8_t       *data)                                                         {int status; *data = VTransUserCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
+      void     transReadData                 (uint16_t      *data)                                                         {int status; *data = VTransUserCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
+      void     transReadData                 (uint32_t      *data)                                                         {int status; *data = VTransUserCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
+      void     transReadData                 (uint64_t      *data)                                                         {int status; *data = VTransUserCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
 
-      bool     transTryReadData              (uint8_t       *data)                                                         {int status; *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint8_t) 0, &status, 0, node); return status;}
-      bool     transTryReadData              (uint16_t      *data)                                                         {int status; *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint16_t)0, &status, 0, node); return status;}
-      bool     transTryReadData              (uint32_t      *data)                                                         {int status; *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint32_t)0, &status, 0, node); return status;}
-      bool     transTryReadData              (uint64_t      *data)                                                         {int status; *data = VTransCommon(ASYNC_READ_DATA, (uint64_t)0, (uint64_t)0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint8_t       *data)                                                         {int status; *data = VTransUserCommon(ASYNC_READ_DATA, (uint32_t)0, (uint8_t) 0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint16_t      *data)                                                         {int status; *data = VTransUserCommon(ASYNC_READ_DATA, (uint32_t)0, (uint16_t)0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint32_t      *data)                                                         {int status; *data = VTransUserCommon(ASYNC_READ_DATA, (uint32_t)0, (uint32_t)0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint64_t      *data)                                                         {int status; *data = VTransUserCommon(ASYNC_READ_DATA, (uint64_t)0, (uint64_t)0, &status, 0, node); return status;}
 
-      void     transReadDataCheck            (uint8_t        data)                                                         {int status; VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
-      void     transReadDataCheck            (uint16_t       data)                                                         {int status; VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
-      void     transReadDataCheck            (uint32_t       data)                                                         {int status; VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
-      void     transReadDataCheck            (uint64_t       data)                                                         {int status; VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint8_t        data)                                                         {int status; VTransUserCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint16_t       data)                                                         {int status; VTransUserCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint32_t       data)                                                         {int status; VTransUserCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint64_t       data)                                                         {int status; VTransUserCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
 
-      bool     transTryReadDataCheck         (uint8_t        data)                                                         {int status; VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
-      bool     transTryReadDataCheck         (uint16_t       data)                                                         {int status; VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
-      bool     transTryReadDataCheck         (uint32_t       data)                                                         {int status; VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
-      bool     transTryReadDataCheck         (uint64_t       data)                                                         {int status; VTransCommon(ASYNC_READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint8_t        data)                                                         {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint16_t       data)                                                         {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint32_t       data)                                                         {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint64_t       data)                                                         {int status; VTransUserCommon(ASYNC_READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node); return status;}
 
-      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint8_t) 0, &status, prot, node);}
-      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint16_t)0, &status, prot, node);}
-      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint32_t)0, &status, prot, node);}
-      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint8_t) 0, &status, prot, node);}
-      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint16_t)0, &status, prot, node);}
-      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint32_t)0, &status, prot, node);}
-      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint64_t)0, &status, prot, node);}
+      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint8_t) 0, &status, prot, node);}
+      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint16_t)0, &status, prot, node);}
+      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint32_t)0, &status, prot, node);}
+      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint8_t) 0, &status, prot, node);}
+      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint16_t)0, &status, prot, node);}
+      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint32_t)0, &status, prot, node);}
+      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                     {int status; *data = VTransUserCommon(READ_OP, addr, (uint64_t)0, &status, prot, node);}
 
       void     transReadPoll                 (const uint32_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
@@ -158,13 +158,13 @@ public:
       void     transReadPoll                 (const uint64_t addr, uint64_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
 
-      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                     {int status; VTransUserCommon(READ_CHECK, addr, data, &status, prot, node);}
 
       void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
       void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -66,76 +66,76 @@ public:
 #endif
       }
 
-      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
-      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
-      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
-      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
-      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
-      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
-      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0)                       {return VTransWrite(addr, data, prot, node);}
+      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
+      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0)                       {int status; return VTransCommon(WRITE_OP, addr, data, &status, prot, node);}
 
-      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
-      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
-      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
-      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
-      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
-      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
-      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0)                       {return VTransWriteAsync(addr, data, prot, node);}
+      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
+      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0)                       {int status; return VTransCommon(ASYNC_WRITE, addr, data, &status, prot, node);}
 
-      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(WRITE_AND_READ, addr, wdata, &status, prot, node);}
 
-      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)     {int status; *rdata = VTransCommon(ASYNC_WRITE_AND_READ, addr, wdata, &status, prot, node);}
 
-      void     transWriteAddressAsync        (const uint32_t addr)                                                         {VTransWriteAddressAsync(addr, node);}
-      void     transWriteAddressAsync        (const uint64_t addr)                                                         {VTransWriteAddressAsync(addr, node);}
+      void     transWriteAddressAsync        (const uint32_t addr)                                                         {int status; VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, 0, node);}
+      void     transWriteAddressAsync        (const uint64_t addr)                                                         {int status; VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, 0, node);}
 
-      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                  {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                  {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                  {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                  {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                  {int status; VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
+      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                  {int status; VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
+      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                  {int status; VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &status, 0, node);}
+      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                  {int status; VTransCommon(ASYNC_WRITE_DATA, (uint64_t)bytelane, data, &status, 0, node);}
 
-      void     transReadAddressAsync         (const uint32_t addr)                                                         {VTransReadAddressAsync(addr, node);}
-      void     transReadAddressAsync         (const uint64_t addr)                                                         {VTransReadAddressAsync(addr, node);}
+      void     transReadAddressAsync         (const uint32_t addr)                                                         {int status; VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, 0, node);}
+      void     transReadAddressAsync         (const uint64_t addr)                                                         {int status; VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, 0, node);}
 
-      void     transReadData                 (uint8_t       *data)                                                         {VTransReadData(data, node);}
-      void     transReadData                 (uint16_t      *data)                                                         {VTransReadData(data, node);}
-      void     transReadData                 (uint32_t      *data)                                                         {VTransReadData(data, node);}
-      void     transReadData                 (uint64_t      *data)                                                         {VTransReadData(data, node);}
+      void     transReadData                 (uint8_t       *data)                                                         {int status; *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
+      void     transReadData                 (uint16_t      *data)                                                         {int status; *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
+      void     transReadData                 (uint32_t      *data)                                                         {int status; *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
+      void     transReadData                 (uint64_t      *data)                                                         {int status; *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);}
 
-      bool     transTryReadData              (uint8_t       *data)                                                         {return VTransTryReadData(data, node);}
-      bool     transTryReadData              (uint16_t      *data)                                                         {return VTransTryReadData(data, node);}
-      bool     transTryReadData              (uint32_t      *data)                                                         {return VTransTryReadData(data, node);}
-      bool     transTryReadData              (uint64_t      *data)                                                         {return VTransTryReadData(data, node);}
+      bool     transTryReadData              (uint8_t       *data)                                                         {int status; *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint8_t) 0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint16_t      *data)                                                         {int status; *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint16_t)0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint32_t      *data)                                                         {int status; *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint32_t)0, &status, 0, node); return status;}
+      bool     transTryReadData              (uint64_t      *data)                                                         {int status; *data = VTransCommon(ASYNC_READ_DATA, (uint64_t)0, (uint64_t)0, &status, 0, node); return status;}
 
-      void     transReadDataCheck            (uint8_t        data)                                                         {VTransReadCheckData(data, node);}
-      void     transReadDataCheck            (uint16_t       data)                                                         {VTransReadCheckData(data, node);}
-      void     transReadDataCheck            (uint32_t       data)                                                         {VTransReadCheckData(data, node);}
-      void     transReadDataCheck            (uint64_t       data)                                                         {VTransReadCheckData(data, node);}
+      void     transReadDataCheck            (uint8_t        data)                                                         {int status; VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint16_t       data)                                                         {int status; VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint32_t       data)                                                         {int status; VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
+      void     transReadDataCheck            (uint64_t       data)                                                         {int status; VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);}
 
-      bool     transTryReadDataCheck         (uint8_t        data)                                                         {return VTransTryReadCheckData(data, node);}
-      bool     transTryReadDataCheck         (uint16_t       data)                                                         {return VTransTryReadCheckData(data, node);}
-      bool     transTryReadDataCheck         (uint32_t       data)                                                         {return VTransTryReadCheckData(data, node);}
-      bool     transTryReadDataCheck         (uint64_t       data)                                                         {return VTransTryReadCheckData(data, node);}
+      bool     transTryReadDataCheck         (uint8_t        data)                                                         {int status; VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint16_t       data)                                                         {int status; VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint32_t       data)                                                         {int status; VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node); return status;}
+      bool     transTryReadDataCheck         (uint64_t       data)                                                         {int status; VTransCommon(ASYNC_READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node); return status;}
 
-      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
-      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                     {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint8_t) 0, &status, prot, node);}
+      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint16_t)0, &status, prot, node);}
+      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint32_t)0, &status, prot, node);}
+      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint8_t) 0, &status, prot, node);}
+      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint16_t)0, &status, prot, node);}
+      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint32_t)0, &status, prot, node);}
+      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                     {int status; *data = VTransCommon(READ_OP, addr, (uint64_t)0, &status, prot, node);}
 
       void     transReadPoll                 (const uint32_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
@@ -158,46 +158,48 @@ public:
       void     transReadPoll                 (const uint64_t addr, uint64_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0)
                                                  {do {tick(waittime); transRead(addr, data, prot);} while((*data & (1 << idx)) != ((bitval & 1) << idx));}
 
-      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
-      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                     {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                     {int status; VTransCommon(READ_CHECK, addr, data, &status, prot, node);}
 
-      void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWrite(addr, data, bytesize, prot, node);}
-      void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWrite(addr, data, bytesize, prot, node);}
-      void     transBurstWrite               (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstWrite(addr, bytesize, prot, node);}
-      void     transBurstWrite               (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstWrite(addr, bytesize, prot, node);}
-      void     transBurstWriteAsync          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
-      void     transBurstWriteAsync          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
+      void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
+      void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
+      void     transBurstWrite               (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(WRITE_BURST, BURST_TRANS, addr, null, bytesize, prot, node);}
+      void     transBurstWrite               (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(WRITE_BURST, BURST_TRANS, addr, null, bytesize, prot, node);}
+      void     transBurstWriteAsync          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
+      void     transBurstWriteAsync          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);}
 
-      void     transBurstWriteIncrement      (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteIncrement(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteIncrement      (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteIncrement(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteIncrementAsync (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteIncrementAsync(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteIncrementAsync (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteIncrementAsync(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteRandom         (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandom(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteRandom         (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandom(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteRandomAsync    (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
-      void     transBurstWriteRandomAsync    (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrement      (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_INCR, addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrement      (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_INCR, addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrementAsync (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrementAsync (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandom         (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_RAND, addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandom         (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(WRITE_BURST, BURST_RAND, addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandomAsync    (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandomAsync    (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, &data, bytesize, prot, node);}
 
-      void     transBurstPushData            (      uint8_t *data, const int bytesize)                                     {VTransBurstPushData(data, bytesize, node);}
-      void     transBurstPushIncrement       (      uint8_t  data, const int bytesize)                                     {VTransBurstPushIncrement(&data, bytesize, node);}
-      void     transBurstPushRandom          (      uint8_t  data, const int bytesize)                                     {VTransBurstPushRandom(&data, bytesize, node);}
+      void     transBurstPushData            (      uint8_t *data, const int bytesize)                                     {VTransBurstCommon(WRITE_BURST, BURST_DATA,      (uint32_t)0,  data, bytesize, (uint32_t)0, node);}
+      void     transBurstPushIncrement       (      uint8_t  data, const int bytesize)                                     {VTransBurstCommon(WRITE_BURST, BURST_INCR_PUSH, (uint32_t)0, &data, bytesize, (uint32_t)0, node);}
+      void     transBurstPushRandom          (      uint8_t  data, const int bytesize)                                     {VTransBurstCommon(WRITE_BURST, BURST_RAND_PUSH, (uint32_t)0, &data, bytesize, (uint32_t)0, node);}
 
-      void     transBurstRead                (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstRead (addr, data, bytesize, prot, node);}
-      void     transBurstRead                (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstRead (addr, data, bytesize, prot, node);}
-      void     transBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstRead (addr, bytesize, prot, node);}
-      void     transBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstRead (addr, bytesize, prot, node);}
-      void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadIncrement(addr, &data, bytesize, prot, node);}
-      void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadIncrement(addr, &data, bytesize, prot, node);}
-      void     transBurstReadCheckRandom     (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadRandom(addr, &data, bytesize, prot, node);}
-      void     transBurstReadCheckRandom     (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadRandom(addr, &data, bytesize, prot, node);}
-      void     transBurstPopData             (uint8_t  *data, const int bytesize)                                          {VTransBurstPopData(data, bytesize, node);}
+      void     transBurstRead                (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_NORM,  addr, data, bytesize, prot, node);}
+      void     transBurstRead                (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_NORM,  addr, data, bytesize, prot, node);}
+      void     transBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(READ_BURST, BURST_TRANS, addr, null, bytesize, prot, node);}
+      void     transBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0)                 {VTransBurstCommon(READ_BURST, BURST_TRANS, addr, null, bytesize, prot, node);}
 
-      void     transBurstCheckIncrement      (      uint8_t  data, const int bytesize)                                     {VTransCheckBurstIncrement(&data, bytesize, node);}
-      void     transBurstCheckRandom         (      uint8_t  data, const int bytesize)                                     {VTransCheckBurstRandom   (&data, bytesize, node);}
+      void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_INCR, addr, &data, bytesize, prot, node);}
+      void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_INCR, addr, &data, bytesize, prot, node);}
+      void     transBurstReadCheckRandom     (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_RAND, addr, &data, bytesize, prot, node);}
+      void     transBurstReadCheckRandom     (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransBurstCommon(READ_BURST, BURST_RAND, addr, &data, bytesize, prot, node);}
+
+      void     transBurstPopData             (uint8_t  *data, const int bytesize)                                          {VTransBurstCommon(READ_BURST, BURST_DATA, (uint32_t)0, data, bytesize, 0, node);}
+
+      void     transBurstCheckIncrement      (      uint8_t  data, const int bytesize)                                     {VTransBurstCommon(READ_BURST, BURST_INCR_CHECK, (uint32_t)0, &data, bytesize, (uint32_t)0, node);}
+      void     transBurstCheckRandom         (      uint8_t  data, const int bytesize)                                     {VTransBurstCommon(READ_BURST, BURST_RAND_CHECK, (uint32_t)0, &data, bytesize, (uint32_t)0, node);}
 
       bool     transBurstCheckData           (      uint8_t *expdata, const int bytesize)
                                              {uint8_t buf[max_data_buf_size]; transBurstPopData(buf, bytesize); return cmpBuffers(buf, expdata, bytesize);}

--- a/code/OsvvmCosim.h
+++ b/code/OsvvmCosim.h
@@ -64,70 +64,111 @@ public:
 #endif
       }
 
-      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0) {return VTransWrite(addr, data, prot, node);}
-      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
-      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
-      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
-      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
-      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
-      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
-      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0) {return VTransWriteAsync(addr, data, prot, node);}
+      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
+      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
+      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
+      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
+      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
+      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
+      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0)                     {return VTransWrite(addr, data, prot, node);}
 
-      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
+      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
+      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
+      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
+      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
+      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
+      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0)                     {return VTransWriteAsync(addr, data, prot, node);}
 
-      void     transWriteAddressAsync (const uint32_t addr)                                          {VTransWriteAddressAsync(addr, node);}
-      void     transWriteAddressAsync (const uint64_t addr)                                          {VTransWriteAddressAsync(addr, node);}
-      void     transWriteDataAsync    (const uint8_t  data, uint32_t bytelane = 0)                   {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync    (const uint16_t data, uint32_t bytelane = 0)                   {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync    (const uint32_t data, uint32_t bytelane = 0)                   {VTransWriteDataAsync(data, bytelane, node);}
-      void     transWriteDataAsync    (const uint64_t data, uint32_t bytelane = 0)                   {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
+      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndRead(addr, wdata, prot, node);}
 
-      void     transReadAddressAsync  (const uint32_t addr)                                          {VTransReadAddressAsync(addr, node);}
-      void     transReadAddressAsync  (const uint64_t addr)                                          {VTransReadAddressAsync(addr, node);}
-      void     transReadData          (uint8_t       *data, const int prot = 0)                      {VTransReadData(data, node);}
-      void     transReadData          (uint16_t      *data, const int prot = 0)                      {VTransReadData(data, node);}
-      void     transReadData          (uint32_t      *data, const int prot = 0)                      {VTransReadData(data, node);}
-      void     transReadData          (uint64_t      *data, const int prot = 0)                      {VTransReadData(data, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0)   {*rdata = VTransWriteAndReadAsync(addr, wdata, prot, node);}
 
-      void     transRead              (const uint32_t addr, uint8_t  *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
-      void     transRead              (const uint32_t addr, uint16_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
-      void     transRead              (const uint32_t addr, uint32_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
-      void     transRead              (const uint64_t addr, uint8_t  *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
-      void     transRead              (const uint64_t addr, uint16_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
-      void     transRead              (const uint64_t addr, uint32_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
-      void     transRead              (const uint64_t addr, uint64_t *data, const int prot = 0)      {VTransRead(addr, data, prot, node);}
+      void     transWriteAddressAsync        (const uint32_t addr)                                                       {VTransWriteAddressAsync(addr, node);}
+      void     transWriteAddressAsync        (const uint64_t addr)                                                       {VTransWriteAddressAsync(addr, node);}
 
-      void     transBurstWrite        (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWrite(addr, data, bytesize, prot, node);}
-      void     transBurstWrite        (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWrite(addr, data, bytesize, prot, node);}
-      void     transBurstWriteAsync   (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
-      void     transBurstWriteAsync   (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
-      void     transBurstRead         (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstRead (addr, data, bytesize, prot, node);}
-      void     transBurstRead         (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {VTransBurstRead (addr, data, bytesize, prot, node);}
+      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                {VTransWriteDataAsync(data, bytelane, node);}
+      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                {VTransWriteDataAsync(data, bytelane, node);}
 
-      void     regInterruptCB         (pVUserInt_t func) {VRegInterrupt(func, node);}
+      void     transReadAddressAsync         (const uint32_t addr)                                                       {VTransReadAddressAsync(addr, node);}
+      void     transReadAddressAsync         (const uint64_t addr)                                                       {VTransReadAddressAsync(addr, node);}
 
-      void     waitForSim             (void)             {VWaitForSim(node);}
+      void     transReadData                 (uint8_t       *data)                                                       {VTransReadData(data, node);}
+      void     transReadData                 (uint16_t      *data)                                                       {VTransReadData(data, node);}
+      void     transReadData                 (uint32_t      *data)                                                       {VTransReadData(data, node);}
+      void     transReadData                 (uint64_t      *data)                                                       {VTransReadData(data, node);}
 
-      int      getNodeNumber          (void)             {return node;}
+      bool     transTryReadData              (uint8_t       *data)                                                       {return VTransTryReadData(data, node);}
+      bool     transTryReadData              (uint16_t      *data)                                                       {return VTransTryReadData(data, node);}
+      bool     transTryReadData              (uint32_t      *data)                                                       {return VTransTryReadData(data, node);}
+      bool     transTryReadData              (uint64_t      *data)                                                       {return VTransTryReadData(data, node);}
+
+      void     transReadDataCheck            (uint8_t        data)                                                       {VTransReadCheckData(data, node);}
+      void     transReadDataCheck            (uint16_t       data)                                                       {VTransReadCheckData(data, node);}
+      void     transReadDataCheck            (uint32_t       data)                                                       {VTransReadCheckData(data, node);}
+      void     transReadDataCheck            (uint64_t       data)                                                       {VTransReadCheckData(data, node);}
+
+      bool     transTryReadDataCheck         (uint8_t        data)                                                       {return VTransTryReadCheckData(data, node);}
+      bool     transTryReadDataCheck         (uint16_t       data)                                                       {return VTransTryReadCheckData(data, node);}
+      bool     transTryReadDataCheck         (uint32_t       data)                                                       {return VTransTryReadCheckData(data, node);}
+      bool     transTryReadDataCheck         (uint64_t       data)                                                       {return VTransTryReadCheckData(data, node);}
+
+      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
+      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                    {VTransRead(addr, data, prot, node);}
+
+      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
+      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                    {VTransReadCheck(addr, data, prot, node);}
+
+      void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWrite(addr, data, bytesize, prot, node);}
+      void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWrite(addr, data, bytesize, prot, node);}
+      void     transBurstWriteAsync          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
+      void     transBurstWriteAsync          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstWriteAsync(addr, data, bytesize, prot, node);}
+
+      void     transBurstWriteIncrement      (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteIncrement(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrement      (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteIncrement(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrementAsync (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteIncrementAsync(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteIncrementAsync (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteIncrementAsync(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandom         (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteRandom(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandom         (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteRandom(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandomAsync    (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
+      void     transBurstWriteRandomAsync    (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)   {VTransBurstWriteRandomAsync(addr, &data, bytesize, prot, node);}
+
+      void     transBurstRead                (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstRead (addr, data, bytesize, prot, node);}
+      void     transBurstRead                (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0) {VTransBurstRead (addr, data, bytesize, prot, node);}
+      void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadIncrement(addr, &data, bytesize, prot, node);}
+      void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadIncrement(addr, &data, bytesize, prot, node);}
+      void     transBurstReadCheckRandom     (const uint32_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadRandom(addr, &data, bytesize, prot, node);}
+      void     transBurstReadCheckRandom     (const uint64_t addr, uint8_t   data, const int bytesize, const int prot = 0) {VTransCheckBurstReadRandom(addr, &data, bytesize, prot, node);}
+
+      void     regInterruptCB                (pVUserInt_t func)                                                            {VRegInterrupt(func, node);}
+
+      void     waitForSim                    (void)                                                                        {VWaitForSim(node);}
+
+      int      getNodeNumber                 (void)                                                                        {return node;}
 
 private:
 

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -83,7 +83,7 @@ public:
                    }
                };
 
-      // Override OsvvmCosim transacti       on methods to insert processINt methods before call to the parent class's methods
+      // Override OsvvmCosim transaction methods to insert processInt methods before call to the parent class's methods
       uint8_t  transWrite                    (const uint32_t addr, const uint8_t  data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
       uint16_t transWrite                    (const uint32_t addr, const uint16_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
       uint32_t transWrite                    (const uint32_t addr, const uint32_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
@@ -190,10 +190,12 @@ public:
       void     transBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0)                    {processInt(); OsvvmCosim::transBurstRead (addr, bytesize, prot);}
       void     transBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0)                    {processInt(); OsvvmCosim::transBurstRead (addr, bytesize, prot);}
 
-      void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
-      void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
-      void     transBurstReadCheckRandom     (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
-      void     transBurstReadCheckRandom     (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
+      void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t  data, const int bytesize, const int prot = 0)     {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
+      void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t  data, const int bytesize, const int prot = 0)     {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
+      void     transBurstReadCheckRandom     (const uint32_t addr, uint8_t  data, const int bytesize, const int prot = 0)     {processInt(); OsvvmCosim::transBurstReadCheckRandom(addr, data, bytesize, prot);}
+      void     transBurstReadCheckRandom     (const uint64_t addr, uint8_t  data, const int bytesize, const int prot = 0)     {processInt(); OsvvmCosim::transBurstReadCheckRandom(addr, data, bytesize, prot);}
+      bool     transBurstReadCheckData       (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0)     {processInt(); return OsvvmCosim::transBurstReadCheckData(addr, data, bytesize, prot);}
+      bool     transBurstReadCheckData       (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0)     {processInt(); return OsvvmCosim::transBurstReadCheckData(addr, data, bytesize, prot);}
 
       void     tick                          (const int ticks, const bool done = false, const bool error = false)             {processInt(); OsvvmCosim::tick(ticks, done, error);}
 
@@ -210,7 +212,7 @@ public:
 
       void registerIsr                       (const pVUserInt_t isrFunc, const unsigned level)                                {if (level < max_interrupts) isr[level] = isrFunc;}
 
-private:
+protected:
       // Process any outstanding interrupts. Will process in priority
       // order, with 0 being the highest. The ISRs can be interrupted
       // by higher priority interrupts.
@@ -254,21 +256,22 @@ private:
           }
       }
 
+private:
 
       // Function pointers for ISRs
       pVUserInt_t isr[max_interrupts];
 
       // Interrupt status vector
-      uint32_t   int_active;
+      uint32_t    int_active;
 
       // Interrupt enable vector
-      uint32_t   int_enabled;
+      uint32_t    int_enabled;
 
       // Interrupt master enable
-      bool       int_master_enable;
+      bool        int_master_enable;
 
       // Interrupts request input state
-      uint32_t   int_req;
+      uint32_t    int_req;
 };
 
 #endif

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -198,8 +198,8 @@ public:
       bool     transBurstReadCheckData       (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0)     {processInt(); return OsvvmCosim::transBurstReadCheckData(addr, data, bytesize, prot);}
 
       void     transWaitForTransaction       (void)                                                                           {processInt(); OsvvmCosim::transWaitForTransaction();}
-      void     transWaitWriteForTransaction  (void)                                                                           {processInt(); OsvvmCosim::transWaitWriteForTransaction();}
-      void     transWaitReadForTransaction   (void)                                                                           {processInt(); OsvvmCosim::transWaitReadForTransaction();}
+      void     transWaitForWriteTransaction  (void)                                                                           {processInt(); OsvvmCosim::transWaitForWriteTransaction();}
+      void     transWaitForReadTransaction   (void)                                                                           {processInt(); OsvvmCosim::transWaitForReadTransaction();}
 
       void     tick                          (const int ticks, const bool done = false, const bool error = false)             {processInt(); OsvvmCosim::tick(ticks, done, error);}
 

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -106,13 +106,13 @@ public:
       void     transWriteAndRead             (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
       void     transWriteAndRead             (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
       void     transWriteAndRead             (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync        (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync        (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync        (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync        (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync        (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync        (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync        (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync        (const uint32_t addr, const uint8_t  wdata, const int prot = 0)                  {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, prot);}
+      void     transWriteAndReadAsync        (const uint32_t addr, const uint16_t wdata, const int prot = 0)                  {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, prot);}
+      void     transWriteAndReadAsync        (const uint32_t addr, const uint32_t wdata, const int prot = 0)                  {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, prot);}
+      void     transWriteAndReadAsync        (const uint64_t addr, const uint8_t  wdata, const int prot = 0)                  {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, prot);}
+      void     transWriteAndReadAsync        (const uint64_t addr, const uint16_t wdata, const int prot = 0)                  {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, prot);}
+      void     transWriteAndReadAsync        (const uint64_t addr, const uint32_t wdata, const int prot = 0)                  {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, prot);}
+      void     transWriteAndReadAsync        (const uint64_t addr, const uint64_t wdata, const int prot = 0)                  {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, prot);}
 
       void     transWriteAddressAsync        (const uint32_t addr)                                                            {processInt(); OsvvmCosim::transWriteAddressAsync(addr);}
       void     transWriteAddressAsync        (const uint64_t addr)                                                            {processInt(); OsvvmCosim::transWriteAddressAsync(addr);}

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -119,7 +119,7 @@ public:
       void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
       void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
       void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
-      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
+      void     transWriteDataAsync           (const uint64_t data, uint64_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
 
       void     transReadAddressAsync         (const uint32_t addr)                                                            {processInt(); OsvvmCosim::transReadAddressAsync(addr);}
       void     transReadAddressAsync         (const uint64_t addr)                                                            {processInt(); OsvvmCosim::transReadAddressAsync(addr);}

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -83,80 +83,120 @@ public:
                    }
                };
 
-      // Override OsvvmCosim transaction methods to insert processINt methods before call to the parent class's methods
-      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
-      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
-      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
-      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
-      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
-      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
-      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      // Override OsvvmCosim transacti       on methods to insert processINt methods before call to the parent class's methods
+      uint8_t  transWrite                    (const uint32_t addr, const uint8_t  data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint16_t transWrite                    (const uint32_t addr, const uint16_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint32_t transWrite                    (const uint32_t addr, const uint32_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint8_t  transWrite                    (const uint64_t addr, const uint8_t  data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint16_t transWrite                    (const uint64_t addr, const uint16_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint32_t transWrite                    (const uint64_t addr, const uint32_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint64_t transWrite                    (const uint64_t addr, const uint64_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint8_t  transWriteAsync               (const uint32_t addr, const uint8_t  data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint16_t transWriteAsync               (const uint32_t addr, const uint16_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint32_t transWriteAsync               (const uint32_t addr, const uint32_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint8_t  transWriteAsync               (const uint64_t addr, const uint8_t  data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint16_t transWriteAsync               (const uint64_t addr, const uint16_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint32_t transWriteAsync               (const uint64_t addr, const uint32_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint64_t transWriteAsync               (const uint64_t addr, const uint64_t data, const int prot = 0)                   {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
 
-      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
-      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
-      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
-      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
-      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
-      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
-      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
-      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndRead             (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead             (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead             (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead             (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead             (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead             (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead             (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync        (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync        (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync        (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync        (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync        (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync        (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync        (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
 
-      void     transWriteAddressAsync (const uint32_t addr)                                     {processInt(); OsvvmCosim::transWriteAddressAsync(addr);}
-      void     transWriteAddressAsync (const uint64_t addr)                                     {processInt(); OsvvmCosim::transWriteAddressAsync(addr);}
-      void     transWriteDataAsync    (const uint8_t  data, uint32_t bytelane = 0)              {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
-      void     transWriteDataAsync    (const uint16_t data, uint32_t bytelane = 0)              {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
-      void     transWriteDataAsync    (const uint32_t data, uint32_t bytelane = 0)              {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
-      void     transWriteDataAsync    (const uint64_t data, uint32_t bytelane = 0)              {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
+      void     transWriteAddressAsync        (const uint32_t addr)                                                            {processInt(); OsvvmCosim::transWriteAddressAsync(addr);}
+      void     transWriteAddressAsync        (const uint64_t addr)                                                            {processInt(); OsvvmCosim::transWriteAddressAsync(addr);}
+      void     transWriteDataAsync           (const uint8_t  data, uint32_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
+      void     transWriteDataAsync           (const uint16_t data, uint32_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
+      void     transWriteDataAsync           (const uint32_t data, uint32_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
+      void     transWriteDataAsync           (const uint64_t data, uint32_t bytelane = 0)                                     {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
 
-      void     transReadAddressAsync  (const uint32_t addr)                                     {processInt(); OsvvmCosim::transReadAddressAsync(addr);}
-      void     transReadAddressAsync  (const uint64_t addr)                                     {processInt(); OsvvmCosim::transReadAddressAsync(addr);}
-      void     transReadData          (uint8_t       *data, const int prot = 0)                 {processInt(); OsvvmCosim::transReadData(data, prot);}
-      void     transReadData          (uint16_t      *data, const int prot = 0)                 {processInt(); OsvvmCosim::transReadData(data, prot);}
-      void     transReadData          (uint32_t      *data, const int prot = 0)                 {processInt(); OsvvmCosim::transReadData(data, prot);}
-      void     transReadData          (uint64_t      *data, const int prot = 0)                 {processInt(); OsvvmCosim::transReadData(data, prot);}
+      void     transReadAddressAsync         (const uint32_t addr)                                                            {processInt(); OsvvmCosim::transReadAddressAsync(addr);}
+      void     transReadAddressAsync         (const uint64_t addr)                                                            {processInt(); OsvvmCosim::transReadAddressAsync(addr);}
 
-      void     transRead              (const uint32_t addr, uint8_t  *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead              (const uint32_t addr, uint16_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead              (const uint32_t addr, uint32_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead              (const uint64_t addr, uint8_t  *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead              (const uint64_t addr, uint16_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead              (const uint64_t addr, uint32_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead              (const uint64_t addr, uint64_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transReadData                 (uint8_t       *data)                                                            {processInt(); OsvvmCosim::transReadData(data);}
+      void     transReadData                 (uint16_t      *data)                                                            {processInt(); OsvvmCosim::transReadData(data);}
+      void     transReadData                 (uint32_t      *data)                                                            {processInt(); OsvvmCosim::transReadData(data);}
+      void     transReadData                 (uint64_t      *data)                                                            {processInt(); OsvvmCosim::transReadData(data);}
 
-      void     transBurstWrite        (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
-      void     transBurstWrite        (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
-      void     transBurstWriteAsync   (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWriteAsync(addr, data, bytesize, prot);}
-      void     transBurstWriteAsync   (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWriteAsync(addr, data, bytesize, prot);}
-      void     transBurstRead         (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
-      void     transBurstRead         (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
+      bool     transTryReadData              (uint8_t       *data)                                                            {processInt(); return OsvvmCosim::transTryReadData(data);}
+      bool     transTryReadData              (uint16_t      *data)                                                            {processInt(); return OsvvmCosim::transTryReadData(data);}
+      bool     transTryReadData              (uint32_t      *data)                                                            {processInt(); return OsvvmCosim::transTryReadData(data);}
+      bool     transTryReadData              (uint64_t      *data)                                                            {processInt(); return OsvvmCosim::transTryReadData(data);}
 
-      void     tick                   (const int ticks, const bool done = false, const bool error = false) {processInt(); OsvvmCosim::tick(ticks, done, error);}
+      void     transReadDataCheck            (uint8_t        data)                                                            {processInt(); OsvvmCosim::transReadDataCheck(data);}
+      void     transReadDataCheck            (uint16_t       data)                                                            {processInt(); OsvvmCosim::transReadDataCheck(data);}
+      void     transReadDataCheck            (uint32_t       data)                                                            {processInt(); OsvvmCosim::transReadDataCheck(data);}
+      void     transReadDataCheck            (uint64_t       data)                                                            {processInt(); OsvvmCosim::transReadDataCheck(data);}
+
+      bool     transTryReadDataCheck         (uint8_t        data)                                                            {processInt(); return OsvvmCosim::transTryReadDataCheck(data);}
+      bool     transTryReadDataCheck         (uint16_t       data)                                                            {processInt(); return OsvvmCosim::transTryReadDataCheck(data);}
+      bool     transTryReadDataCheck         (uint32_t       data)                                                            {processInt(); return OsvvmCosim::transTryReadDataCheck(data);}
+      bool     transTryReadDataCheck         (uint64_t       data)                                                            {processInt(); return OsvvmCosim::transTryReadDataCheck(data);}
+
+      void     transRead                     (const uint32_t addr, uint8_t  *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead                     (const uint32_t addr, uint16_t *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead                     (const uint32_t addr, uint32_t *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead                     (const uint64_t addr, uint8_t  *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead                     (const uint64_t addr, uint16_t *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+
+      void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
+      void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
+      void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
+      void     transReadCheck                (const uint64_t addr, uint8_t   data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
+      void     transReadCheck                (const uint64_t addr, uint16_t  data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
+      void     transReadCheck                (const uint64_t addr, uint32_t  data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
+      void     transReadCheck                (const uint64_t addr, uint64_t  data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
+
+      void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
+      void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
+      void     transBurstWriteAsync          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstWriteAsync(addr, data, bytesize, prot);}
+      void     transBurstWriteAsync          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstWriteAsync(addr, data, bytesize, prot);}
+
+      void     transBurstWriteIncrement      (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstWriteIncrement(addr, data, bytesize, prot);}
+      void     transBurstWriteIncrement      (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstWriteIncrement(addr, data, bytesize, prot);}
+      void     transBurstWriteIncrementAsync (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstWriteIncrementAsync(addr, data, bytesize, prot);}
+      void     transBurstWriteIncrementAsync (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstWriteIncrementAsync(addr, data, bytesize, prot);}
+
+      void     transBurstWriteRandom         (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstWriteRandom(addr, data, bytesize, prot);}
+      void     transBurstWriteRandom         (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstWriteRandom(addr, data, bytesize, prot);}
+      void     transBurstWriteRandomAsync    (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstWriteRandomAsync(addr, data, bytesize, prot);}
+      void     transBurstWriteRandomAsync    (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstWriteRandomAsync(addr, data, bytesize, prot);}
+
+      void     transBurstRead                (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
+      void     transBurstRead                (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
+
+      void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
+      void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
+      void     transBurstReadCheckRandom     (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
+      void     transBurstReadCheckRandom     (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
+
+      void     tick                          (const int ticks, const bool done = false, const bool error = false)             {processInt(); OsvvmCosim::tick(ticks, done, error);}
 
       // Enable/disable master interrupt
-      void enableMasterInterrupt      (void) {int_master_enable = true;}
-      void disableMasterInterrupt     (void) {int_master_enable = false;}
+      void enableMasterInterrupt             (void)                                                                           {int_master_enable = true;}
+      void disableMasterInterrupt            (void)                                                                           {int_master_enable = false;}
 
       // Enable/disable individual interrupts
-      void enableIsr                  (const int int_num) {if (int_num < max_interrupts && isr[int_num] != NULL) {int_enabled |=  (1 << (int_num & (max_interrupts-1)));}}
-      void disableIsr                 (const int int_num) {int_enabled &= ~(1 << (int_num & (max_interrupts-1)));}
+      void enableIsr                         (const int int_num)                                                              {if (int_num < max_interrupts && isr[int_num] != NULL) {int_enabled |=  (1 << (int_num & (max_interrupts-1)));}}
+      void disableIsr                        (const int int_num)                                                              {int_enabled &= ~(1 << (int_num & (max_interrupts-1)));}
 
       // Interrupt input. Call from external registered callback function
-      int  updateIntReq               (const uint32_t intReq) {int_req = intReq; return 0;}
+      int  updateIntReq                      (const uint32_t intReq)                                                          {int_req = intReq; return 0;}
 
-      void registerIsr                (const pVUserInt_t isrFunc, const unsigned level) {if (level < max_interrupts) isr[level] = isrFunc;}
+      void registerIsr                       (const pVUserInt_t isrFunc, const unsigned level)                                {if (level < max_interrupts) isr[level] = isrFunc;}
 
 private:
       // Process any outstanding interrupts. Will process in priority

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -152,6 +152,14 @@ public:
       void     transRead                     (const uint64_t addr, uint32_t *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
       void     transRead                     (const uint64_t addr, uint64_t *data, const int prot = 0)                        {processInt(); OsvvmCosim::transRead(addr, data, prot);}
 
+      void     transReadPoll                 (const uint32_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0) {processInt(); OsvvmCosim::transReadPoll(addr, data, idx, bitval, waittime, prot);}
+      void     transReadPoll                 (const uint32_t addr, uint16_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0) {processInt(); OsvvmCosim::transReadPoll(addr, data, idx, bitval, waittime, prot);}
+      void     transReadPoll                 (const uint32_t addr, uint32_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0) {processInt(); OsvvmCosim::transReadPoll(addr, data, idx, bitval, waittime, prot);}
+      void     transReadPoll                 (const uint64_t addr, uint8_t  *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0) {processInt(); OsvvmCosim::transReadPoll(addr, data, idx, bitval, waittime, prot);}
+      void     transReadPoll                 (const uint64_t addr, uint16_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0) {processInt(); OsvvmCosim::transReadPoll(addr, data, idx, bitval, waittime, prot);}
+      void     transReadPoll                 (const uint64_t addr, uint32_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0) {processInt(); OsvvmCosim::transReadPoll(addr, data, idx, bitval, waittime, prot);}
+      void     transReadPoll                 (const uint64_t addr, uint64_t *data, const int idx, const int bitval, const int waittime = 10, const int prot = 0) {processInt(); OsvvmCosim::transReadPoll(addr, data, idx, bitval, waittime, prot);}
+
       void     transReadCheck                (const uint32_t addr, uint8_t   data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
       void     transReadCheck                (const uint32_t addr, uint16_t  data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}
       void     transReadCheck                (const uint32_t addr, uint32_t  data, const int prot = 0)                        {processInt(); OsvvmCosim::transReadCheck(addr, data, prot);}

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -170,6 +170,8 @@ public:
 
       void     transBurstWrite               (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
       void     transBurstWrite               (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
+      void     transBurstWrite               (const uint32_t addr, const int bytesize, const int prot = 0)                    {processInt(); OsvvmCosim::transBurstWrite(addr, bytesize, prot);}
+      void     transBurstWrite               (const uint64_t addr, const int bytesize, const int prot = 0)                    {processInt(); OsvvmCosim::transBurstWrite(addr, bytesize, prot);}
       void     transBurstWriteAsync          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstWriteAsync(addr, data, bytesize, prot);}
       void     transBurstWriteAsync          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstWriteAsync(addr, data, bytesize, prot);}
 
@@ -185,6 +187,8 @@ public:
 
       void     transBurstRead                (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
       void     transBurstRead                (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)    {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
+      void     transBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0)                    {processInt(); OsvvmCosim::transBurstRead (addr, bytesize, prot);}
+      void     transBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0)                    {processInt(); OsvvmCosim::transBurstRead (addr, bytesize, prot);}
 
       void     transBurstReadCheckIncrement  (const uint32_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}
       void     transBurstReadCheckIncrement  (const uint64_t addr, uint8_t data, const int bytesize, const int prot = 0)      {processInt(); OsvvmCosim::transBurstReadCheckIncrement(addr, data, bytesize, prot);}

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -197,6 +197,10 @@ public:
       bool     transBurstReadCheckData       (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0)     {processInt(); return OsvvmCosim::transBurstReadCheckData(addr, data, bytesize, prot);}
       bool     transBurstReadCheckData       (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0)     {processInt(); return OsvvmCosim::transBurstReadCheckData(addr, data, bytesize, prot);}
 
+      void     transWaitForTransaction       (void)                                                                           {processInt(); OsvvmCosim::transWaitForTransaction();}
+      void     transWaitWriteForTransaction  (void)                                                                           {processInt(); OsvvmCosim::transWaitWriteForTransaction();}
+      void     transWaitReadForTransaction   (void)                                                                           {processInt(); OsvvmCosim::transWaitReadForTransaction();}
+
       void     tick                          (const int ticks, const bool done = false, const bool error = false)             {processInt(); OsvvmCosim::tick(ticks, done, error);}
 
       // Enable/disable master interrupt

--- a/code/OsvvmCosimInt.h
+++ b/code/OsvvmCosimInt.h
@@ -16,12 +16,14 @@
 //
 //  Revision History:
 //    Date      Version    Description
-//    11/2022   2023.01    Initial revision
+//    05/2023   2023.05    Adding asynchronous transaction support
+//    03/2023   2023.04    Adding basic stream support
+//    01/2023   2023.01    Initial revision
 //
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -82,41 +84,79 @@ public:
                };
 
       // Override OsvvmCosim transaction methods to insert processINt methods before call to the parent class's methods
-      uint8_t  transWrite      (const uint32_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint16_t transWrite      (const uint32_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint32_t transWrite      (const uint32_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint8_t  transWrite      (const uint64_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint16_t transWrite      (const uint64_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint32_t transWrite      (const uint64_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
-      uint64_t transWrite      (const uint64_t addr, const uint64_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint8_t  transWrite             (const uint32_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint16_t transWrite             (const uint32_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint32_t transWrite             (const uint32_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint8_t  transWrite             (const uint64_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint16_t transWrite             (const uint64_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint32_t transWrite             (const uint64_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint64_t transWrite             (const uint64_t addr, const uint64_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWrite(addr, data, prot);}
+      uint8_t  transWriteAsync        (const uint32_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint16_t transWriteAsync        (const uint32_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint32_t transWriteAsync        (const uint32_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint8_t  transWriteAsync        (const uint64_t addr, const uint8_t  data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint16_t transWriteAsync        (const uint64_t addr, const uint16_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint32_t transWriteAsync        (const uint64_t addr, const uint32_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
+      uint64_t transWriteAsync        (const uint64_t addr, const uint64_t data, const int prot = 0) {processInt(); return OsvvmCosim::transWriteAsync(addr, data, prot);}
 
-      void     transRead       (const uint32_t addr, uint8_t  *data,      const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead       (const uint32_t addr, uint16_t *data,      const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead       (const uint32_t addr, uint32_t *data,      const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead       (const uint64_t addr, uint8_t  *data,      const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead       (const uint64_t addr, uint16_t *data,      const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead       (const uint64_t addr, uint32_t *data,      const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
-      void     transRead       (const uint64_t addr, uint64_t *data,      const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transWriteAndRead      (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead      (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead      (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead      (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead      (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead      (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndRead      (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndRead(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync (const uint32_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint8_t  wdata, uint8_t  *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint16_t wdata, uint16_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint32_t wdata, uint32_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
+      void     transWriteAndReadAsync (const uint64_t addr, const uint64_t wdata, uint64_t *rdata, const int prot = 0) {processInt(); OsvvmCosim::transWriteAndReadAsync(addr, wdata, rdata, prot);}
 
-      void     transBurstWrite (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
-      void     transBurstWrite (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
-      void     transBurstRead  (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
-      void     transBurstRead  (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
+      void     transWriteAddressAsync (const uint32_t addr)                                     {processInt(); OsvvmCosim::transWriteAddressAsync(addr);}
+      void     transWriteAddressAsync (const uint64_t addr)                                     {processInt(); OsvvmCosim::transWriteAddressAsync(addr);}
+      void     transWriteDataAsync    (const uint8_t  data, uint32_t bytelane = 0)              {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
+      void     transWriteDataAsync    (const uint16_t data, uint32_t bytelane = 0)              {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
+      void     transWriteDataAsync    (const uint32_t data, uint32_t bytelane = 0)              {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
+      void     transWriteDataAsync    (const uint64_t data, uint32_t bytelane = 0)              {processInt(); OsvvmCosim::transWriteDataAsync(data, bytelane);}
 
-      void     tick            (const int ticks, const bool done = false, const bool error = false) {processInt(); OsvvmCosim::tick(ticks, done, error);}
+      void     transReadAddressAsync  (const uint32_t addr)                                     {processInt(); OsvvmCosim::transReadAddressAsync(addr);}
+      void     transReadAddressAsync  (const uint64_t addr)                                     {processInt(); OsvvmCosim::transReadAddressAsync(addr);}
+      void     transReadData          (uint8_t       *data, const int prot = 0)                 {processInt(); OsvvmCosim::transReadData(data, prot);}
+      void     transReadData          (uint16_t      *data, const int prot = 0)                 {processInt(); OsvvmCosim::transReadData(data, prot);}
+      void     transReadData          (uint32_t      *data, const int prot = 0)                 {processInt(); OsvvmCosim::transReadData(data, prot);}
+      void     transReadData          (uint64_t      *data, const int prot = 0)                 {processInt(); OsvvmCosim::transReadData(data, prot);}
+
+      void     transRead              (const uint32_t addr, uint8_t  *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead              (const uint32_t addr, uint16_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead              (const uint32_t addr, uint32_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead              (const uint64_t addr, uint8_t  *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead              (const uint64_t addr, uint16_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead              (const uint64_t addr, uint32_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+      void     transRead              (const uint64_t addr, uint64_t *data, const int prot = 0) {processInt(); OsvvmCosim::transRead(addr, data, prot);}
+
+      void     transBurstWrite        (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
+      void     transBurstWrite        (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWrite(addr, data, bytesize, prot);}
+      void     transBurstWriteAsync   (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWriteAsync(addr, data, bytesize, prot);}
+      void     transBurstWriteAsync   (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstWriteAsync(addr, data, bytesize, prot);}
+      void     transBurstRead         (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
+      void     transBurstRead         (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0)  {processInt(); OsvvmCosim::transBurstRead (addr, data, bytesize, prot);}
+
+      void     tick                   (const int ticks, const bool done = false, const bool error = false) {processInt(); OsvvmCosim::tick(ticks, done, error);}
 
       // Enable/disable master interrupt
-      void enableMasterInterrupt  (void) {int_master_enable = true;}
-      void disableMasterInterrupt (void) {int_master_enable = false;}
+      void enableMasterInterrupt      (void) {int_master_enable = true;}
+      void disableMasterInterrupt     (void) {int_master_enable = false;}
 
       // Enable/disable individual interrupts
-      void enableIsr              (const int int_num) {if (int_num < max_interrupts && isr[int_num] != NULL) {int_enabled |=  (1 << (int_num & (max_interrupts-1)));}}
-      void disableIsr             (const int int_num) {int_enabled &= ~(1 << (int_num & (max_interrupts-1)));}
+      void enableIsr                  (const int int_num) {if (int_num < max_interrupts && isr[int_num] != NULL) {int_enabled |=  (1 << (int_num & (max_interrupts-1)));}}
+      void disableIsr                 (const int int_num) {int_enabled &= ~(1 << (int_num & (max_interrupts-1)));}
 
       // Interrupt input. Call from external registered callback function
-      int  updateIntReq           (const uint32_t intReq) {int_req = intReq; return 0;}
+      int  updateIntReq               (const uint32_t intReq) {int_req = intReq; return 0;}
 
-      void registerIsr            (const pVUserInt_t isrFunc, const unsigned level) {if (level < max_interrupts) isr[level] = isrFunc;}
+      void registerIsr                (const pVUserInt_t isrFunc, const unsigned level) {if (level < max_interrupts) isr[level] = isrFunc;}
 
 private:
       // Process any outstanding interrupts. Will process in priority

--- a/code/OsvvmCosimResp.h
+++ b/code/OsvvmCosimResp.h
@@ -1,0 +1,152 @@
+// =========================================================================
+//
+//  File Name:         OsvvmCosimResp.h
+//  Design Unit Name:
+//  Revision:          OSVVM MODELS STANDARD VERSION
+//
+//  Maintainer:        Simon Southwell email:  simon.southwell@gmail.com
+//  Contributor(s):
+//     Simon Southwell      simon.southwell@gmail.com
+//
+//
+//  Description:
+//      Simulator co-simulation virtual procedure C++ class for user
+//      side responder code. Virtualises away top level VP user
+//      thread routines.
+//
+//  Revision History:
+//    Date      Version    Description
+//    05/2023   2023.05    Initial revision
+//
+//
+//  This file is part of OSVVM.
+//
+//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+// =========================================================================
+
+#include <stdint.h>
+#include <string>
+#include "OsvvmVUser.h"
+
+#ifndef __OSVVM_COSIM_RESP_H_
+#define __OSVVM_COSIM_RESP_H_
+
+class OsvvmCosimResp
+{
+public:
+                const int max_data_buf_size = DATABUF_SIZE;
+
+                OsvvmCosimResp (int nodeIn = 1, std::string test_name = "") : node(nodeIn) {
+                   if (test_name.compare(""))
+                   {
+                       VSetTestName(test_name.c_str(), test_name.length(), node);
+                   }
+                };
+
+      void     tick            (const int ticks, const bool done = false, const bool error = false)
+      {
+#ifndef DISABLE_VUSERMAIN_THREAD
+          VTick(ticks, done, error, node);
+#else
+          VTick(ticks, false, error, node);
+#endif
+      }
+      void      respGetWrite                 (uint32_t *addr, uint8_t*  data)     {*data = VTransUserCommon(WRITE_OP, addr, (uint8_t) 0, &dummyStatus, 0, node);}
+      void      respGetWrite                 (uint32_t *addr, uint16_t* data)     {*data = VTransUserCommon(WRITE_OP, addr, (uint16_t)0, &dummyStatus, 0, node);}
+      void      respGetWrite                 (uint32_t *addr, uint32_t* data)     {*data = VTransUserCommon(WRITE_OP, addr, (uint32_t)0, &dummyStatus, 0, node);}
+      void      respGetWrite                 (uint64_t *addr, uint8_t*  data)     {*data = VTransUserCommon(WRITE_OP, addr, (uint8_t)0,  &dummyStatus, 0, node);}
+      void      respGetWrite                 (uint64_t *addr, uint16_t* data)     {*data = VTransUserCommon(WRITE_OP, addr, (uint16_t)0, &dummyStatus, 0, node);}
+      void      respGetWrite                 (uint64_t *addr, uint32_t* data)     {*data = VTransUserCommon(WRITE_OP, addr, (uint32_t)0, &dummyStatus, 0, node);}
+      void      respGetWrite                 (uint64_t *addr, uint64_t* data)     {*data = VTransUserCommon(WRITE_OP, addr, (uint64_t)0, &dummyStatus, 0, node);}
+
+      bool      respTryGetWrite              (uint32_t *addr, uint8_t*  data)     {int status; *data = VTransUserCommon(ASYNC_WRITE, addr, (uint8_t) 0, &status, 0, node); return status;}
+      bool      respTryGetWrite              (uint32_t *addr, uint16_t* data)     {int status; *data = VTransUserCommon(ASYNC_WRITE, addr, (uint16_t)0, &status, 0, node); return status;}
+      bool      respTryGetWrite              (uint32_t *addr, uint32_t* data)     {int status; *data = VTransUserCommon(ASYNC_WRITE, addr, (uint32_t)0, &status, 0, node); return status;}
+      bool      respTryGetWrite              (uint64_t *addr, uint8_t*  data)     {int status; *data = VTransUserCommon(ASYNC_WRITE, addr, (uint8_t)0,  &status, 0, node); return status;}
+      bool      respTryGetWrite              (uint64_t *addr, uint16_t* data)     {int status; *data = VTransUserCommon(ASYNC_WRITE, addr, (uint16_t)0, &status, 0, node); return status;}
+      bool      respTryGetWrite              (uint64_t *addr, uint32_t* data)     {int status; *data = VTransUserCommon(ASYNC_WRITE, addr, (uint32_t)0, &status, 0, node); return status;}
+      bool      respTryGetWrite              (uint64_t *addr, uint64_t* data)     {int status; *data = VTransUserCommon(ASYNC_WRITE, addr, (uint64_t)0, &status, 0, node); return status;}
+
+      void      respGetWriteAddress          (uint32_t* addr)                     {VTransUserCommon(WRITE_ADDRESS, addr, (uint32_t)0, &dummyStatus, 0, node);}
+      void      respGetWriteAddress          (uint64_t* addr)                     {VTransUserCommon(WRITE_ADDRESS, addr, (uint64_t)0, &dummyStatus, 0, node);}
+
+      bool      respTryGetWriteAddress       (uint32_t* addr)                     {int status; VTransUserCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &status, 0, node); return status;}
+      bool      respTryGetWriteAddress       (uint64_t* addr)                     {int status; VTransUserCommon(ASYNC_WRITE_ADDRESS, addr, (uint64_t)0, &status, 0, node); return status;}
+
+      void      respGetWriteData             (uint8_t*  data)                     {*data = VTransUserCommon(WRITE_DATA, &dummyAddr32, (uint8_t)0,  &dummyStatus, 0, node);}
+      void      respGetWriteData             (uint16_t* data)                     {*data = VTransUserCommon(WRITE_DATA, &dummyAddr32, (uint16_t)0, &dummyStatus, 0, node);}
+      void      respGetWriteData             (uint32_t* data)                     {*data = VTransUserCommon(WRITE_DATA, &dummyAddr32, (uint32_t)0, &dummyStatus, 0, node);}
+      void      respGetWriteData             (uint64_t* data)                     {*data = VTransUserCommon(WRITE_DATA, &dummyAddr64, (uint64_t)0, &dummyStatus, 0, node);}
+
+      bool      respTryGetWriteData          (uint8_t*  data)                     {int status; *data = VTransUserCommon(ASYNC_WRITE_DATA, &dummyAddr32, (uint8_t)0,  &status, 0, node); return status;}
+      bool      respTryGetWriteData          (uint16_t* data)                     {int status; *data = VTransUserCommon(ASYNC_WRITE_DATA, &dummyAddr32, (uint16_t)0, &status, 0, node); return status;}
+      bool      respTryGetWriteData          (uint32_t* data)                     {int status; *data = VTransUserCommon(ASYNC_WRITE_DATA, &dummyAddr32, (uint32_t)0, &status, 0, node); return status;}
+      bool      respTryGetWriteData          (uint64_t* data)                     {int status; *data = VTransUserCommon(ASYNC_WRITE_DATA, &dummyAddr64, (uint64_t)0, &status, 0, node); return status;}
+
+
+      void      respSendRead                 (uint32_t* addr, uint8_t  data)      {VTransUserCommon(READ_OP, addr, data, &dummyStatus, 0, node);}
+      void      respSendRead                 (uint32_t* addr, uint16_t data)      {VTransUserCommon(READ_OP, addr, data, &dummyStatus, 0, node);}
+      void      respSendRead                 (uint32_t* addr, uint32_t data)      {VTransUserCommon(READ_OP, addr, data, &dummyStatus, 0, node);}
+      void      respSendRead                 (uint64_t* addr, uint8_t  data)      {VTransUserCommon(READ_OP, addr, data, &dummyStatus, 0, node);}
+      void      respSendRead                 (uint64_t* addr, uint16_t data)      {VTransUserCommon(READ_OP, addr, data, &dummyStatus, 0, node);}
+      void      respSendRead                 (uint64_t* addr, uint32_t data)      {VTransUserCommon(READ_OP, addr, data, &dummyStatus, 0, node);}
+      void      respSendRead                 (uint64_t* addr, uint64_t data)      {VTransUserCommon(READ_OP, addr, data, &dummyStatus, 0, node);}
+
+      bool      respTrySendRead              (uint32_t* addr, uint8_t  data)      {int status; VTransUserCommon(ASYNC_READ, addr, data, &status, 0, node); return status;}
+      bool      respTrySendRead              (uint32_t* addr, uint16_t data)      {int status; VTransUserCommon(ASYNC_READ, addr, data, &status, 0, node); return status;}
+      bool      respTrySendRead              (uint32_t* addr, uint32_t data)      {int status; VTransUserCommon(ASYNC_READ, addr, data, &status, 0, node); return status;}
+      bool      respTrySendRead              (uint64_t* addr, uint8_t  data)      {int status; VTransUserCommon(ASYNC_READ, addr, data, &status, 0, node); return status;}
+      bool      respTrySendRead              (uint64_t* addr, uint16_t data)      {int status; VTransUserCommon(ASYNC_READ, addr, data, &status, 0, node); return status;}
+      bool      respTrySendRead              (uint64_t* addr, uint32_t data)      {int status; VTransUserCommon(ASYNC_READ, addr, data, &status, 0, node); return status;}
+      bool      respTrySendRead              (uint64_t* addr, uint64_t data)      {int status; VTransUserCommon(ASYNC_READ, addr, data, &status, 0, node); return status;}
+
+      void      respGetReadAddress           (uint32_t* addr)                     {VTransUserCommon(READ_ADDRESS, addr, (uint32_t)0, &dummyStatus, 0, node);}
+      void      respGetReadAddress           (uint64_t* addr)                     {VTransUserCommon(READ_ADDRESS, addr, (uint64_t)0, &dummyStatus, 0, node);}
+
+      bool      respTryGetReadAddress        (uint32_t* addr)                     {int status; VTransUserCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &status, 0, node); return status;}
+      bool      respTryGetReadAddress        (uint64_t* addr)                     {int status; VTransUserCommon(ASYNC_READ_ADDRESS, addr, (uint64_t)0, &status, 0, node); return status;}
+
+      void      respSendReadData             (uint8_t  data)                      {VTransUserCommon(READ_DATA, &dummyAddr32, data, &dummyStatus, 0, node);}
+      void      respSendReadData             (uint16_t data)                      {VTransUserCommon(READ_DATA, &dummyAddr32, data, &dummyStatus, 0, node);}
+      void      respSendReadData             (uint32_t data)                      {VTransUserCommon(READ_DATA, &dummyAddr32, data, &dummyStatus, 0, node);}
+      void      respSendReadData             (uint64_t data)                      {VTransUserCommon(READ_DATA, &dummyAddr64, data, &dummyStatus, 0, node);}
+
+      bool      respSendReadDataAsync        (uint8_t  data)                      {int status; VTransUserCommon(ASYNC_READ_DATA, &dummyAddr32, data, &status, 0, node); return status;}
+      bool      respSendReadDataAsync        (uint16_t data)                      {int status; VTransUserCommon(ASYNC_READ_DATA, &dummyAddr32, data, &status, 0, node); return status;}
+      bool      respSendReadDataAsync        (uint32_t data)                      {int status; VTransUserCommon(ASYNC_READ_DATA, &dummyAddr32, data, &status, 0, node); return status;}
+      bool      respSendReadDataAsync        (uint64_t data)                      {int status; VTransUserCommon(ASYNC_READ_DATA, &dummyAddr64, data, &status, 0, node); return status;}
+
+      void      respWaitForTransaction       (void)                               {VTransTransactionWait(WAIT_FOR_TRANSACTION,       node);}
+      void      respWaitForWriteTransaction  (void)                               {VTransTransactionWait(WAIT_FOR_WRITE_TRANSACTION, node);}
+      void      respWaitForReadTransaction   (void)                               {VTransTransactionWait(WAIT_FOR_READ_TRANSACTION,  node);}
+
+      int       respGetTransactionCount      (void)                               {return VTransGetCount(GET_TRANSACTION_COUNT,       node);}
+      int       respGetWriteTransactionCount (void)                               {return VTransGetCount(GET_WRITE_TRANSACTION_COUNT, node);}
+      int       respGetReadTransactionCount  (void)                               {return VTransGetCount(GET_READ_TRANSACTION_COUNT,  node);}
+
+      void      waitForSim                   (void)                               {VWaitForSim(node);}
+
+      int       getNodeNumber                (void)                               {return node;}
+
+private:
+
+      int      dummyStatus;
+      uint32_t dummyAddr32;
+      uint64_t dummyAddr64;
+      int      node;
+};
+
+#endif

--- a/code/OsvvmCosimSkt.cpp
+++ b/code/OsvvmCosimSkt.cpp
@@ -154,6 +154,7 @@ int OsvvmCosimSkt::init(void)
 
 OsvvmCosimSkt::osvvm_cosim_skt_t OsvvmCosimSkt::connect_skt (const int portno)
 {
+    int enable = 1;
 
     // Create an IPv4 socket byte stream
     osvvm_cosim_skt_t svrskt;
@@ -161,6 +162,14 @@ OsvvmCosimSkt::osvvm_cosim_skt_t OsvvmCosimSkt::connect_skt (const int portno)
     if ((svrskt = socket(AF_INET, SOCK_STREAM, IPPROTO_IP)) < 0)
     {
         VPrint("ERROR opening socket\n");
+        cleanup();
+        return OSVVM_COSIM_ERR;
+    }
+    
+    // Allow a waiting socket to be reused
+    if (setsockopt(svrskt, SOL_SOCKET, SO_REUSEADDR, (char*)&enable, sizeof(int)) < 0)
+    {
+        VPrint("ERROR setting socket option\n");
         cleanup();
         return OSVVM_COSIM_ERR;
     }

--- a/code/OsvvmCosimStream.h
+++ b/code/OsvvmCosimStream.h
@@ -62,45 +62,58 @@ public:
 #endif
       }
 
-      uint8_t  streamSend               (const uint8_t  data, const int param=0)                {return VStreamSend(data, param, node);}
-      uint16_t streamSend               (const uint16_t data, const int param=0)                {return VStreamSend(data, param, node);}
-      uint32_t streamSend               (const uint32_t data, const int param=0)                {return VStreamSend(data, param, node);}
-      uint64_t streamSend               (const uint64_t data, const int param=0)                {return VStreamSend(data, param, node);}
-                                        
-      uint8_t  streamSendAsync          (const uint8_t  data, const int param=0)                {return VStreamSendAsync(data, param, node);}
-      uint16_t streamSendAsync          (const uint16_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
-      uint32_t streamSendAsync          (const uint32_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
-      uint64_t streamSendAsync          (const uint64_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
-                                        
-      void     streamGet                (uint8_t  *data)                                        {int status; VStreamGet(data, &status, node);}
-      void     streamGet                (uint16_t *data)                                        {int status; VStreamGet(data, &status, node);}
-      void     streamGet                (uint32_t *data)                                        {int status; VStreamGet(data, &status, node);}
-      void     streamGet                (uint64_t *data)                                        {int status; VStreamGet(data, &status, node);}
-                                        
-      void     streamGet                (uint8_t  *data, int *status)                           {VStreamGet(data, status, node);}
-      void     streamGet                (uint16_t *data, int *status)                           {VStreamGet(data, status, node);}
-      void     streamGet                (uint32_t *data, int *status)                           {VStreamGet(data, status, node);}
-      void     streamGet                (uint64_t *data, int *status)                           {VStreamGet(data, status, node);}
-                                        
-      void     streamCheck              (const uint8_t  data, const int param=0)                {VStreamCheck(data, param, node);}
-      void     streamCheck              (const uint16_t data, const int param=0)                {VStreamCheck(data, param, node);}
-      void     streamCheck              (const uint32_t data, const int param=0)                {VStreamCheck(data, param, node);}
-      void     streamCheck              (const uint64_t data, const int param=0)                {VStreamCheck(data, param, node);}
-                                        
-      void     streamBurstSend          (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstSend      (data, bytesize, param, node);}
-      void     streamBurstSendAsync     (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstSendAsync (data, bytesize, param, node);}
-      void     streamBurstGet           (uint8_t  *data, const int bytesize)                    {int status; VStreamBurstGet (data, bytesize, &status, node);}
-      void     streamBurstGet           (uint8_t  *data, const int bytesize,       int *status) {VStreamBurstGet       (data, bytesize, status, node);}
-      void     streamBurstGet           (const int bytesize)                                    {int status; VStreamBurstGet (bytesize, &status, node);}
-      void     streamBurstGet           (const int bytesize, int *status)                       {VStreamBurstGet       (bytesize, status, node);}
-      void     streamBurstCheck         (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstCheck     (data, bytesize, param, node);}
-      void     streamBurstSendIncrement (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendIncrement(&data, bytesize, param, node);}
-      void     streamBurstSendRandom    (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendRandom(&data, bytesize, param, node);}
-      void     streamBurstPopData       (uint8_t  *data, const int bytesize)                    {VStreamBurstPopData   (data, bytesize, node);}
+      uint8_t  streamSend                     (const uint8_t  data, const int param=0)                {return VStreamSend(data, param, node);}
+      uint16_t streamSend                     (const uint16_t data, const int param=0)                {return VStreamSend(data, param, node);}
+      uint32_t streamSend                     (const uint32_t data, const int param=0)                {return VStreamSend(data, param, node);}
+      uint64_t streamSend                     (const uint64_t data, const int param=0)                {return VStreamSend(data, param, node);}
 
-      void     waitForSim              (void)                                                  {VWaitForSim(node);}
+      uint8_t  streamSendAsync                (const uint8_t  data, const int param=0)                {return VStreamSendAsync(data, param, node);}
+      uint16_t streamSendAsync                (const uint16_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
+      uint32_t streamSendAsync                (const uint32_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
+      uint64_t streamSendAsync                (const uint64_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
 
-      int      getNodeNumber           (void)                                                  {return node;}
+      void     streamGet                      (uint8_t  *data)                                        {int status; VStreamGet(data, &status, node);}
+      void     streamGet                      (uint16_t *data)                                        {int status; VStreamGet(data, &status, node);}
+      void     streamGet                      (uint32_t *data)                                        {int status; VStreamGet(data, &status, node);}
+      void     streamGet                      (uint64_t *data)                                        {int status; VStreamGet(data, &status, node);}
+
+      void     streamGet                      (uint8_t  *data, int *status)                           {VStreamGet(data, status, node);}
+      void     streamGet                      (uint16_t *data, int *status)                           {VStreamGet(data, status, node);}
+      void     streamGet                      (uint32_t *data, int *status)                           {VStreamGet(data, status, node);}
+      void     streamGet                      (uint64_t *data, int *status)                           {VStreamGet(data, status, node);}
+
+      void     streamCheck                    (const uint8_t  data, const int param=0)                {VStreamCheck(data, param, node);}
+      void     streamCheck                    (const uint16_t data, const int param=0)                {VStreamCheck(data, param, node);}
+      void     streamCheck                    (const uint32_t data, const int param=0)                {VStreamCheck(data, param, node);}
+      void     streamCheck                    (const uint64_t data, const int param=0)                {VStreamCheck(data, param, node);}
+
+      void     streamBurstSend                (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstSend               (data, bytesize, param, node);}
+      void     streamBurstSend                (const int bytesize, const int param=0)                 {VStreamBurstSend               (bytesize, param, node);}
+      void     streamBurstSendAsync           (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstSendAsync          (data, bytesize, param, node);}
+      void     streamBurstSendAsync           (const int bytesize, const int param=0)                 {VStreamBurstSendAsync          (bytesize, param, node);}
+      void     streamBurstGet                 (uint8_t  *data, const int bytesize)                    {int status; VStreamBurstGet    (data, bytesize, &status, node);}
+      void     streamBurstGet                 (uint8_t  *data, const int bytesize,       int *status) {VStreamBurstGet                (data, bytesize, status, node);}
+      void     streamBurstGet                 (const int bytesize)                                    {int status; VStreamBurstGet    (bytesize, &status, node);}
+      void     streamBurstGet                 (const int bytesize, int *status)                       {VStreamBurstGet                (bytesize, status, node);}
+      void     streamBurstCheck               (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstCheck              (data, bytesize, param, node);}
+      void     streamBurstCheck               (const int bytesize, const int param=0)                 {VStreamBurstCheck              (bytesize, param, node);}
+      void     streamBurstCheckIncrement      (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstCheckIncrement     (&data, bytesize, param, node);}
+      void     streamBurstCheckRandom         (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstCheckRandom        (&data, bytesize, param, node);}
+      void     streamBurstSendIncrement       (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendIncrement      (&data, bytesize, param, node);}
+      void     streamBurstSendIncrementAsync  (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendIncrementAsync (&data, bytesize, param, node);}
+      void     streamBurstSendRandom          (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendRandom         (&data, bytesize, param, node);}
+      void     streamBurstSendRandomAsync     (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendRandomAsync    (&data, bytesize, param, node);}
+      void     streamBurstPopData             (uint8_t  *data, const int bytesize)                    {VStreamBurstPopData            (data,  bytesize, node);}
+      void     streamBurstPushData            (uint8_t  *data, const int bytesize)                    {VStreamBurstPushData           (data,  bytesize, node);}
+      void     streamBurstPushCheckData       (uint8_t  *data, const int bytesize)                    {VStreamBurstPushCheckData      (data,  bytesize, node);}
+      void     streamBurstPushIncrement       (uint8_t   data, const int bytesize)                    {VStreamBurstPushIncrement      (&data, bytesize, node);}
+      void     streamBurstPushCheckIncrement  (uint8_t   data, const int bytesize)                    {VStreamBurstPushCheckIncrement (&data, bytesize, node);}
+      void     streamBurstPushRandom          (uint8_t   data, const int bytesize)                    {VStreamBurstPushRandom         (&data, bytesize, node);}
+      void     streamBurstPushCheckRandom     (uint8_t   data, const int bytesize)                    {VStreamBurstPushCheckRandom    (&data, bytesize, node);}
+
+      void     waitForSim                     (void)                                                   {VWaitForSim(node);}
+
+      int      getNodeNumber                  (void)                                                   {return node;}
 
 private:
 

--- a/code/OsvvmCosimStream.h
+++ b/code/OsvvmCosimStream.h
@@ -62,27 +62,33 @@ public:
 #endif
       }
 
-      uint8_t  streamSend      (const uint8_t  data, const int param=0) {return VStreamSend(data, param, node);}
-      uint16_t streamSend      (const uint16_t data, const int param=0) {return VStreamSend(data, param, node);}
-      uint32_t streamSend      (const uint32_t data, const int param=0) {return VStreamSend(data, param, node);}
-      uint64_t streamSend      (const uint64_t data, const int param=0) {return VStreamSend(data, param, node);}
+      uint8_t  streamSend           (const uint8_t  data, const int param=0) {return VStreamSend(data, param, node);}
+      uint16_t streamSend           (const uint16_t data, const int param=0) {return VStreamSend(data, param, node);}
+      uint32_t streamSend           (const uint32_t data, const int param=0) {return VStreamSend(data, param, node);}
+      uint64_t streamSend           (const uint64_t data, const int param=0) {return VStreamSend(data, param, node);}
 
-      void     streamGet       (uint8_t  *data)                         {int status; VStreamGet(data, &status, node);}
-      void     streamGet       (uint16_t *data)                         {int status; VStreamGet(data, &status, node);}
-      void     streamGet       (uint32_t *data)                         {int status; VStreamGet(data, &status, node);}
-      void     streamGet       (uint64_t *data)                         {int status; VStreamGet(data, &status, node);}
+      uint8_t  streamSendAsync      (const uint8_t  data, const int param=0) {return VStreamSendAsync(data, param, node);}
+      uint16_t streamSendAsync      (const uint16_t data, const int param=0) {return VStreamSendAsync(data, param, node);}
+      uint32_t streamSendAsync      (const uint32_t data, const int param=0) {return VStreamSendAsync(data, param, node);}
+      uint64_t streamSendAsync      (const uint64_t data, const int param=0) {return VStreamSendAsync(data, param, node);}
 
-      void     streamGet       (uint8_t  *data, int *status)            {VStreamGet(data, status, node);}
-      void     streamGet       (uint16_t *data, int *status)            {VStreamGet(data, status, node);}
-      void     streamGet       (uint32_t *data, int *status)            {VStreamGet(data, status, node);}
-      void     streamGet       (uint64_t *data, int *status)            {VStreamGet(data, status, node);}
+      void     streamGet            (uint8_t  *data)                         {int status; VStreamGet(data, &status, node);}
+      void     streamGet            (uint16_t *data)                         {int status; VStreamGet(data, &status, node);}
+      void     streamGet            (uint32_t *data)                         {int status; VStreamGet(data, &status, node);}
+      void     streamGet            (uint64_t *data)                         {int status; VStreamGet(data, &status, node);}
 
-      void     streamBurstSend (uint8_t  *data, const int bytesize)     {VStreamBurstSend(data, bytesize, node);}
-      void     streamBurstGet  (uint8_t  *data, const int bytesize)     {VStreamBurstGet (data, bytesize, node);}
+      void     streamGet            (uint8_t  *data, int *status)            {VStreamGet(data, status, node);}
+      void     streamGet            (uint16_t *data, int *status)            {VStreamGet(data, status, node);}
+      void     streamGet            (uint32_t *data, int *status)            {VStreamGet(data, status, node);}
+      void     streamGet            (uint64_t *data, int *status)            {VStreamGet(data, status, node);}
 
-      void     waitForSim      (void)                                   {VWaitForSim(node);}
+      void     streamBurstSend      (uint8_t  *data, const int bytesize)     {VStreamBurstSend      (data, bytesize, node);}
+      void     streamBurstSendAsync (uint8_t  *data, const int bytesize)     {VStreamBurstSendAsync (data, bytesize, node);}
+      void     streamBurstGet       (uint8_t  *data, const int bytesize)     {VStreamBurstGet       (data, bytesize, node);}
 
-      int      getNodeNumber   (void)                                   {return node;}
+      void     waitForSim           (void)                                   {VWaitForSim(node);}
+
+      int      getNodeNumber        (void)                                   {return node;}
 
 private:
 

--- a/code/OsvvmCosimStream.h
+++ b/code/OsvvmCosimStream.h
@@ -45,6 +45,9 @@
 
 class OsvvmCosimStream
 {
+private:
+      const int RX_REC = 0;
+      const int TX_REC = 1;
 public:
                 OsvvmCosimStream (int nodeIn = 0, std::string test_name = "") : node(nodeIn) {
                    if (test_name.compare(""))
@@ -92,10 +95,10 @@ public:
       bool     streamTryGet                   (uint32_t *data,            int *status)                     {return VStreamUserGetCommon              (TRY_GET, data, status, 0, 0, node);}
       bool     streamTryGet                   (uint64_t *data,            int *status)                     {return VStreamUserGetCommon              (TRY_GET, data, status, 0, 0, node);}
 
-      bool     streamTryCheck                 (const uint8_t  data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, null, &status, data, param, node);}
-      bool     streamTryCheck                 (const uint16_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, null, &status, data, param, node);}
-      bool     streamTryCheck                 (const uint32_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, null, &status, data, param, node);}
-      bool     streamTryCheck                 (const uint64_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, null, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint8_t  data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, NULL, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint16_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, NULL, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint32_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, NULL, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint64_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, NULL, &status, data, param, node);}
 
       void     streamCheck                    (const uint8_t  data, const int param=0)                     {VStreamUserCommon                        (CHECK, data, param, node);}
       void     streamCheck                    (const uint16_t data, const int param=0)                     {VStreamUserCommon                        (CHECK, data, param, node);}
@@ -103,17 +106,17 @@ public:
       void     streamCheck                    (const uint64_t data, const int param=0)                     {VStreamUserCommon                        (CHECK, data, param, node);}
 
       void     streamBurstSend                (uint8_t  *data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (SEND_BURST, BURST_NORM, data, bytesize, param, node);}
-      void     streamBurstSend                (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (SEND_BURST, BURST_TRANS, null, bytesize, param, node);}
+      void     streamBurstSend                (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (SEND_BURST, BURST_TRANS, NULL, bytesize, param, node);}
       void     streamBurstSendAsync           (uint8_t  *data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (SEND_BURST_ASYNC, BURST_NORM, data, bytesize, param, node);}
-      void     streamBurstSendAsync           (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (SEND_BURST_ASYNC, BURST_TRANS, null, bytesize, param, node);}
+      void     streamBurstSendAsync           (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (SEND_BURST_ASYNC, BURST_TRANS, NULL, bytesize, param, node);}
 
       void     streamBurstGet                 (uint8_t  *data,      const int  bytesize)                   {int status; VStreamUserBurstGetCommon    (GET_BURST, BURST_NORM,  data, bytesize, &status, node);}
       void     streamBurstGet                 (uint8_t  *data,      const int  bytesize, int *status)      {VStreamUserBurstGetCommon                (GET_BURST, BURST_NORM,  data, bytesize, status, node);}
-      void     streamBurstGet                 (const int bytesize)                                         {int status; VStreamUserBurstGetCommon    (GET_BURST, BURST_TRANS, null, bytesize, &status, node);}
-      void     streamBurstGet                 (const int bytesize,        int *status)                     {VStreamUserBurstGetCommon                (GET_BURST, BURST_TRANS, null, bytesize, status, node);}
+      void     streamBurstGet                 (const int bytesize)                                         {int status; VStreamUserBurstGetCommon    (GET_BURST, BURST_TRANS, NULL, bytesize, &status, node);}
+      void     streamBurstGet                 (const int bytesize,        int *status)                     {VStreamUserBurstGetCommon                (GET_BURST, BURST_TRANS, NULL, bytesize, status, node);}
 
       void     streamBurstCheck               (uint8_t  *data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_NORM,  data, bytesize, param, node);}
-      void     streamBurstCheck               (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_TRANS, null, bytesize, param, node);}
+      void     streamBurstCheck               (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_TRANS, NULL, bytesize, param, node);}
       void     streamBurstCheckIncrement      (uint8_t   data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param, node);}
       void     streamBurstCheckRandom         (uint8_t   data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param, node);}
 
@@ -130,12 +133,17 @@ public:
       void     streamBurstPushRandom          (uint8_t   data,      const int bytesize)                    {VStreamUserBurstSendCommon               (SEND_BURST,  BURST_RAND_PUSH, &data, bytesize, 0, node);}
       void     streamBurstPushCheckRandom     (uint8_t   data,      const int bytesize)                    {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_RAND_PUSH, &data, bytesize, 0, node);}
 
-      bool     streamBurstTryGet              (const int bytesize,  const int param=1)                     {int status; return VStreamUserBurstGetCommon(TRY_GET_BURST,   BURST_TRANS,        null, bytesize, &status, node);}
+      bool     streamBurstTryGet              (const int bytesize,  const int param=1)                     {int status; return VStreamUserBurstGetCommon(TRY_GET_BURST,   BURST_TRANS,        NULL, bytesize, &status, node);}
       bool     streamBurstTryGet              (uint8_t  *data,      const int bytesize, const int param=1) {int status; return VStreamUserBurstGetCommon(TRY_GET_BURST,   BURST_NORM,       data, bytesize, &status, node);}
-      bool     streamBurstTryCheck            (const int bytesize,  const int param=1)                     {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_TRANS,        null, bytesize, param,   node);}
+      bool     streamBurstTryCheck            (const int bytesize,  const int param=1)                     {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_TRANS,        NULL, bytesize, param,   node);}
       bool     streamBurstTryCheck            (uint8_t  *data,      const int bytesize, const int param=1) {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_NORM,       data, bytesize, param,   node);}
       bool     streamBurstTryCheckIncrement   (uint8_t   data,      const int bytesize, const int param=1) {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param,   node);}
       bool     streamBurstTryCheckRandom      (uint8_t   data,      const int bytesize, const int param=1) {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param,   node);}
+
+      int      streamGetRxTransactionCount    (void)                                                       {return VStreamWaitGetCount                  (GET_TRANSACTION_COUNT, RX_REC, node);}
+      int      streamGetTxTransactionCount    (void)                                                       {return VStreamWaitGetCount                  (GET_TRANSACTION_COUNT, TX_REC, node);}
+      void     streamWaitForRxTransaction     (void)                                                       {VStreamWaitGetCount                         (WAIT_FOR_TRANSACTION,  RX_REC, node);}
+      void     streamWaitForTxTransaction     (void)                                                       {VStreamWaitGetCount                         (WAIT_FOR_TRANSACTION,  TX_REC, node);}
 
       void     waitForSim                     (void)                                                       {VWaitForSim(node);}
 

--- a/code/OsvvmCosimStream.h
+++ b/code/OsvvmCosimStream.h
@@ -62,80 +62,80 @@ public:
 #endif
       }
 
-      uint8_t  streamSend                     (const uint8_t  data, const int param=0)                     {return VStreamSend                   (data, param, node);}
-      uint16_t streamSend                     (const uint16_t data, const int param=0)                     {return VStreamSend                   (data, param, node);}
-      uint32_t streamSend                     (const uint32_t data, const int param=0)                     {return VStreamSend                   (data, param, node);}
-      uint64_t streamSend                     (const uint64_t data, const int param=0)                     {return VStreamSend                   (data, param, node);}
+      uint8_t  streamSend                     (const uint8_t  data, const int param=0)                     {return VStreamCommon                 (SEND, data, param, node);}
+      uint16_t streamSend                     (const uint16_t data, const int param=0)                     {return VStreamCommon                 (SEND, data, param, node);}
+      uint32_t streamSend                     (const uint32_t data, const int param=0)                     {return VStreamCommon                 (SEND, data, param, node);}
+      uint64_t streamSend                     (const uint64_t data, const int param=0)                     {return VStreamCommon                 (SEND, data, param, node);}
 
-      uint8_t  streamSendAsync                (const uint8_t  data, const int param=0)                     {return VStreamSendAsync              (data, param, node);}
-      uint16_t streamSendAsync                (const uint16_t data, const int param=0)                     {return VStreamSendAsync              (data, param, node);}
-      uint32_t streamSendAsync                (const uint32_t data, const int param=0)                     {return VStreamSendAsync              (data, param, node);}
-      uint64_t streamSendAsync                (const uint64_t data, const int param=0)                     {return VStreamSendAsync              (data, param, node);}
+      uint8_t  streamSendAsync                (const uint8_t  data, const int param=0)                     {return VStreamCommon                 (SEND_ASYNC, data, param, node);}
+      uint16_t streamSendAsync                (const uint16_t data, const int param=0)                     {return VStreamCommon                 (SEND_ASYNC, data, param, node);}
+      uint32_t streamSendAsync                (const uint32_t data, const int param=0)                     {return VStreamCommon                 (SEND_ASYNC, data, param, node);}
+      uint64_t streamSendAsync                (const uint64_t data, const int param=0)                     {return VStreamCommon                 (SEND_ASYNC, data, param, node);}
 
-      void     streamGet                      (uint8_t  *data)                                             {int status; VStreamGet               (data, &status, node);}
-      void     streamGet                      (uint16_t *data)                                             {int status; VStreamGet               (data, &status, node);}
-      void     streamGet                      (uint32_t *data)                                             {int status; VStreamGet               (data, &status, node);}
-      void     streamGet                      (uint64_t *data)                                             {int status; VStreamGet               (data, &status, node);}
+      void     streamGet                      (uint8_t  *data)                                             {int status; VStreamGetCommon         (GET, data, &status, 0, 0, node);}
+      void     streamGet                      (uint16_t *data)                                             {int status; VStreamGetCommon         (GET, data, &status, 0, 0, node);}
+      void     streamGet                      (uint32_t *data)                                             {int status; VStreamGetCommon         (GET, data, &status, 0, 0, node);}
+      void     streamGet                      (uint64_t *data)                                             {int status; VStreamGetCommon         (GET, data, &status, 0, 0, node);}
 
-      void     streamGet                      (uint8_t  *data,            int *status)                     {VStreamGet                           (data, status, node);}
-      void     streamGet                      (uint16_t *data,            int *status)                     {VStreamGet                           (data, status, node);}
-      void     streamGet                      (uint32_t *data,            int *status)                     {VStreamGet                           (data, status, node);}
-      void     streamGet                      (uint64_t *data,            int *status)                     {VStreamGet                           (data, status, node);}
+      void     streamGet                      (uint8_t  *data,            int *status)                     {VStreamGetCommon                     (GET, data, status, 0, 0, node);}
+      void     streamGet                      (uint16_t *data,            int *status)                     {VStreamGetCommon                     (GET, data, status, 0, 0, node);}
+      void     streamGet                      (uint32_t *data,            int *status)                     {VStreamGetCommon                     (GET, data, status, 0, 0, node);}
+      void     streamGet                      (uint64_t *data,            int *status)                     {VStreamGetCommon                     (GET, data, status, 0, 0, node);}
 
-      bool     streamTryGet                   (uint8_t  *data)                                             {int status; return VStreamTryGet     (data, &status, node);}
-      bool     streamTryGet                   (uint16_t *data)                                             {int status; return VStreamTryGet     (data, &status, node);}
-      bool     streamTryGet                   (uint32_t *data)                                             {int status; return VStreamTryGet     (data, &status, node);}
-      bool     streamTryGet                   (uint64_t *data)                                             {int status; return VStreamTryGet     (data, &status, node);}
+      bool     streamTryGet                   (uint8_t  *data)                                             {int status; return VStreamGetCommon  (TRY_GET, data, &status, 0, 0, node);}
+      bool     streamTryGet                   (uint16_t *data)                                             {int status; return VStreamGetCommon  (TRY_GET, data, &status, 0, 0, node);}
+      bool     streamTryGet                   (uint32_t *data)                                             {int status; return VStreamGetCommon  (TRY_GET, data, &status, 0, 0, node);}
+      bool     streamTryGet                   (uint64_t *data)                                             {int status; return VStreamGetCommon  (TRY_GET, data, &status, 0, 0, node);}
 
-      bool     streamTryGet                   (uint8_t  *data,            int *status)                     {return VStreamTryGet                 (data, status, node);}
-      bool     streamTryGet                   (uint16_t *data,            int *status)                     {return VStreamTryGet                 (data, status, node);}
-      bool     streamTryGet                   (uint32_t *data,            int *status)                     {return VStreamTryGet                 (data, status, node);}
-      bool     streamTryGet                   (uint64_t *data,            int *status)                     {return VStreamTryGet                 (data, status, node);}
+      bool     streamTryGet                   (uint8_t  *data,            int *status)                     {return VStreamGetCommon              (TRY_GET, data, status, 0, 0, node);}
+      bool     streamTryGet                   (uint16_t *data,            int *status)                     {return VStreamGetCommon              (TRY_GET, data, status, 0, 0, node);}
+      bool     streamTryGet                   (uint32_t *data,            int *status)                     {return VStreamGetCommon              (TRY_GET, data, status, 0, 0, node);}
+      bool     streamTryGet                   (uint64_t *data,            int *status)                     {return VStreamGetCommon              (TRY_GET, data, status, 0, 0, node);}
 
-      bool     streamTryCheck                 (const uint8_t  data, const int param=0)                     {return VStreamTryCheck               (data, param, node);}
-      bool     streamTryCheck                 (const uint16_t data, const int param=0)                     {return VStreamTryCheck               (data, param, node);}
-      bool     streamTryCheck                 (const uint32_t data, const int param=0)                     {return VStreamTryCheck               (data, param, node);}
-      bool     streamTryCheck                 (const uint64_t data, const int param=0)                     {return VStreamTryCheck               (data, param, node);}
+      bool     streamTryCheck                 (const uint8_t  data, const int param=0)                     {int status; return VStreamGetCommon  (TRY_CHECK, null, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint16_t data, const int param=0)                     {int status; return VStreamGetCommon  (TRY_CHECK, null, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint32_t data, const int param=0)                     {int status; return VStreamGetCommon  (TRY_CHECK, null, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint64_t data, const int param=0)                     {int status; return VStreamGetCommon  (TRY_CHECK, null, &status, data, param, node);}
 
-      void     streamCheck                    (const uint8_t  data, const int param=0)                     {VStreamCheck                         (data, param, node);}
-      void     streamCheck                    (const uint16_t data, const int param=0)                     {VStreamCheck                         (data, param, node);}
-      void     streamCheck                    (const uint32_t data, const int param=0)                     {VStreamCheck                         (data, param, node);}
-      void     streamCheck                    (const uint64_t data, const int param=0)                     {VStreamCheck                         (data, param, node);}
+      void     streamCheck                    (const uint8_t  data, const int param=0)                     {VStreamCommon                        (CHECK, data, param, node);}
+      void     streamCheck                    (const uint16_t data, const int param=0)                     {VStreamCommon                        (CHECK, data, param, node);}
+      void     streamCheck                    (const uint32_t data, const int param=0)                     {VStreamCommon                        (CHECK, data, param, node);}
+      void     streamCheck                    (const uint64_t data, const int param=0)                     {VStreamCommon                        (CHECK, data, param, node);}
 
-      void     streamBurstSend                (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSend                     (data, bytesize, param, node);}
-      void     streamBurstSend                (const int bytesize,  const int param=1)                     {VStreamBurstSend                     (bytesize, param, node);}
-      void     streamBurstSendAsync           (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSendAsync                (data, bytesize, param, node);}
-      void     streamBurstSendAsync           (const int bytesize,  const int param=1)                     {VStreamBurstSendAsync                (bytesize, param, node);}
+      void     streamBurstSend                (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST, BURST_NORM, data, bytesize, param, node);}
+      void     streamBurstSend                (const int bytesize,  const int param=1)                     {VStreamBurstSendCommon               (SEND_BURST, BURST_TRANS, null, bytesize, param, node);}
+      void     streamBurstSendAsync           (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST_ASYNC, BURST_NORM, data, bytesize, param, node);}
+      void     streamBurstSendAsync           (const int bytesize,  const int param=1)                     {VStreamBurstSendCommon               (SEND_BURST_ASYNC, BURST_TRANS, null, bytesize, param, node);}
 
-      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize)                   {int status; VStreamBurstGet          (data, bytesize, &status, node);}
-      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize, int *status)      {VStreamBurstGet                      (data, bytesize, status, node);}
-      void     streamBurstGet                 (const int bytesize)                                         {int status; VStreamBurstGet          (bytesize, &status, node);}
-      void     streamBurstGet                 (const int bytesize,        int *status)                     {VStreamBurstGet                      (bytesize, status, node);}
+      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize)                   {int status; VStreamBurstGetCommon    (GET_BURST, BURST_NORM,  data, bytesize, &status, node);}
+      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize, int *status)      {VStreamBurstGetCommon                (GET_BURST, BURST_NORM,  data, bytesize, status, node);}
+      void     streamBurstGet                 (const int bytesize)                                         {int status; VStreamBurstGetCommon    (GET_BURST, BURST_TRANS, null, bytesize, &status, node);}
+      void     streamBurstGet                 (const int bytesize,        int *status)                     {VStreamBurstGetCommon                (GET_BURST, BURST_TRANS, null, bytesize, status, node);}
 
-      void     streamBurstCheck               (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstCheck                    (data, bytesize, param, node);}
-      void     streamBurstCheck               (const int bytesize,  const int param=1)                     {VStreamBurstCheck                    (bytesize, param, node);}
-      void     streamBurstCheckIncrement      (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstCheckIncrement           (&data, bytesize, param, node);}
-      void     streamBurstCheckRandom         (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstCheckRandom              (&data, bytesize, param, node);}
+      void     streamBurstCheck               (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (CHECK_BURST, BURST_NORM,  data, bytesize, param, node);}
+      void     streamBurstCheck               (const int bytesize,  const int param=1)                     {VStreamBurstSendCommon               (CHECK_BURST, BURST_TRANS, null, bytesize, param, node);}
+      void     streamBurstCheckIncrement      (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param, node);}
+      void     streamBurstCheckRandom         (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param, node);}
 
-      void     streamBurstSendIncrement       (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendIncrement            (&data, bytesize, param, node);}
-      void     streamBurstSendIncrementAsync  (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendIncrementAsync       (&data, bytesize, param, node);}
-      void     streamBurstSendRandom          (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendRandom               (&data, bytesize, param, node);}
-      void     streamBurstSendRandomAsync     (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendRandomAsync          (&data, bytesize, param, node);}
+      void     streamBurstSendIncrement       (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST, BURST_INCR, &data, bytesize, param, node);}
+      void     streamBurstSendIncrementAsync  (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST_ASYNC, BURST_INCR, &data, bytesize, param, node);}
+      void     streamBurstSendRandom          (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST, BURST_RAND, &data, bytesize, param, node);}
+      void     streamBurstSendRandomAsync     (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST_ASYNC, BURST_RAND, &data, bytesize, param, node);}
 
-      void     streamBurstPopData             (uint8_t  *data,      const int bytesize)                    {VStreamBurstPopData                  (data,  bytesize, node);}
-      void     streamBurstPushData            (uint8_t  *data,      const int bytesize)                    {VStreamBurstPushData                 (data,  bytesize, node);}
-      void     streamBurstPushCheckData       (uint8_t  *data,      const int bytesize)                    {VStreamBurstPushCheckData            (data,  bytesize, node);}
-      void     streamBurstPushIncrement       (uint8_t   data,      const int bytesize)                    {VStreamBurstPushIncrement            (&data, bytesize, node);}
-      void     streamBurstPushCheckIncrement  (uint8_t   data,      const int bytesize)                    {VStreamBurstPushCheckIncrement       (&data, bytesize, node);}
-      void     streamBurstPushRandom          (uint8_t   data,      const int bytesize)                    {VStreamBurstPushRandom               (&data, bytesize, node);}
-      void     streamBurstPushCheckRandom     (uint8_t   data,      const int bytesize)                    {VStreamBurstPushCheckRandom          (&data, bytesize, node);}
+      void     streamBurstPopData             (uint8_t  *data,      const int bytesize)                    {int status; VStreamBurstGetCommon    (GET_BURST,   BURST_DATA,       data, bytesize, &status, node);}
+      void     streamBurstPushData            (uint8_t  *data,      const int bytesize)                    {VStreamBurstSendCommon               (SEND_BURST,  BURST_DATA,       data, bytesize, 0, node);}
+      void     streamBurstPushCheckData       (uint8_t  *data,      const int bytesize)                    {VStreamBurstSendCommon               (CHECK_BURST, BURST_DATA,       data, bytesize, 0, node);}
+      void     streamBurstPushIncrement       (uint8_t   data,      const int bytesize)                    {VStreamBurstSendCommon               (SEND_BURST,  BURST_INCR_PUSH, &data, bytesize, 0, node);}
+      void     streamBurstPushCheckIncrement  (uint8_t   data,      const int bytesize)                    {VStreamBurstSendCommon               (CHECK_BURST, BURST_INCR_PUSH, &data, bytesize, 0, node);}
+      void     streamBurstPushRandom          (uint8_t   data,      const int bytesize)                    {VStreamBurstSendCommon               (SEND_BURST,  BURST_RAND_PUSH, &data, bytesize, 0, node);}
+      void     streamBurstPushCheckRandom     (uint8_t   data,      const int bytesize)                    {VStreamBurstSendCommon               (CHECK_BURST, BURST_RAND_PUSH, &data, bytesize, 0, node);}
 
-      bool     streamBurstTryGet              (const int bytesize,  const int param=1)                     {return VStreamBurstTryGet            (bytesize, param, node);}
-      bool     streamBurstTryGet              (uint8_t  *data,      const int bytesize, const int param=1) {return VStreamBurstTryGet            (data, bytesize, param, node);}
-      bool     streamBurstTryCheck            (const int bytesize,  const int param=1)                     {return VStreamBurstTryCheck          (bytesize, param, node);}
-      bool     streamBurstTryCheck            (uint8_t  *data,      const int bytesize, const int param=1) {return VStreamBurstTryCheck          (data, bytesize, param, node);}
-      bool     streamBurstTryCheckIncrement   (uint8_t   data,      const int bytesize, const int param=1) {return VStreamBurstTryCheckIncrement (&data, bytesize, param, node);}
-      bool     streamBurstTryCheckRandom      (uint8_t   data,      const int bytesize, const int param=1) {return VStreamBurstTryCheckRandom    (&data, bytesize, param, node);}
+      bool     streamBurstTryGet              (const int bytesize,  const int param=1)                     {int status; return VStreamBurstGetCommon(TRY_GET_BURST,   BURST_TRANS,        null, bytesize, &status, node);}
+      bool     streamBurstTryGet              (uint8_t  *data,      const int bytesize, const int param=1) {int status; return VStreamBurstGetCommon(TRY_GET_BURST,   BURST_NORM,       data, bytesize, &status, node);}
+      bool     streamBurstTryCheck            (const int bytesize,  const int param=1)                     {return VStreamBurstSendCommon           (TRY_CHECK_BURST, BURST_TRANS,        null, bytesize, param,   node);}
+      bool     streamBurstTryCheck            (uint8_t  *data,      const int bytesize, const int param=1) {return VStreamBurstSendCommon           (TRY_CHECK_BURST, BURST_NORM,       data, bytesize, param,   node);}
+      bool     streamBurstTryCheckIncrement   (uint8_t   data,      const int bytesize, const int param=1) {return VStreamBurstSendCommon           (TRY_CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param,   node);}
+      bool     streamBurstTryCheckRandom      (uint8_t   data,      const int bytesize, const int param=1) {return VStreamBurstSendCommon           (TRY_CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param,   node);}
 
       void     waitForSim                     (void)                                                       {VWaitForSim(node);}
 

--- a/code/OsvvmCosimStream.h
+++ b/code/OsvvmCosimStream.h
@@ -62,80 +62,80 @@ public:
 #endif
       }
 
-      uint8_t  streamSend                     (const uint8_t  data, const int param=0)                     {return VStreamCommon                 (SEND, data, param, node);}
-      uint16_t streamSend                     (const uint16_t data, const int param=0)                     {return VStreamCommon                 (SEND, data, param, node);}
-      uint32_t streamSend                     (const uint32_t data, const int param=0)                     {return VStreamCommon                 (SEND, data, param, node);}
-      uint64_t streamSend                     (const uint64_t data, const int param=0)                     {return VStreamCommon                 (SEND, data, param, node);}
+      uint8_t  streamSend                     (const uint8_t  data, const int param=0)                     {return VStreamUserCommon                 (SEND, data, param, node);}
+      uint16_t streamSend                     (const uint16_t data, const int param=0)                     {return VStreamUserCommon                 (SEND, data, param, node);}
+      uint32_t streamSend                     (const uint32_t data, const int param=0)                     {return VStreamUserCommon                 (SEND, data, param, node);}
+      uint64_t streamSend                     (const uint64_t data, const int param=0)                     {return VStreamUserCommon                 (SEND, data, param, node);}
 
-      uint8_t  streamSendAsync                (const uint8_t  data, const int param=0)                     {return VStreamCommon                 (SEND_ASYNC, data, param, node);}
-      uint16_t streamSendAsync                (const uint16_t data, const int param=0)                     {return VStreamCommon                 (SEND_ASYNC, data, param, node);}
-      uint32_t streamSendAsync                (const uint32_t data, const int param=0)                     {return VStreamCommon                 (SEND_ASYNC, data, param, node);}
-      uint64_t streamSendAsync                (const uint64_t data, const int param=0)                     {return VStreamCommon                 (SEND_ASYNC, data, param, node);}
+      uint8_t  streamSendAsync                (const uint8_t  data, const int param=0)                     {return VStreamUserCommon                 (SEND_ASYNC, data, param, node);}
+      uint16_t streamSendAsync                (const uint16_t data, const int param=0)                     {return VStreamUserCommon                 (SEND_ASYNC, data, param, node);}
+      uint32_t streamSendAsync                (const uint32_t data, const int param=0)                     {return VStreamUserCommon                 (SEND_ASYNC, data, param, node);}
+      uint64_t streamSendAsync                (const uint64_t data, const int param=0)                     {return VStreamUserCommon                 (SEND_ASYNC, data, param, node);}
 
-      void     streamGet                      (uint8_t  *data)                                             {int status; VStreamGetCommon         (GET, data, &status, 0, 0, node);}
-      void     streamGet                      (uint16_t *data)                                             {int status; VStreamGetCommon         (GET, data, &status, 0, 0, node);}
-      void     streamGet                      (uint32_t *data)                                             {int status; VStreamGetCommon         (GET, data, &status, 0, 0, node);}
-      void     streamGet                      (uint64_t *data)                                             {int status; VStreamGetCommon         (GET, data, &status, 0, 0, node);}
+      void     streamGet                      (uint8_t  *data)                                             {int status; VStreamUserGetCommon         (GET, data, &status, 0, 0, node);}
+      void     streamGet                      (uint16_t *data)                                             {int status; VStreamUserGetCommon         (GET, data, &status, 0, 0, node);}
+      void     streamGet                      (uint32_t *data)                                             {int status; VStreamUserGetCommon         (GET, data, &status, 0, 0, node);}
+      void     streamGet                      (uint64_t *data)                                             {int status; VStreamUserGetCommon         (GET, data, &status, 0, 0, node);}
 
-      void     streamGet                      (uint8_t  *data,            int *status)                     {VStreamGetCommon                     (GET, data, status, 0, 0, node);}
-      void     streamGet                      (uint16_t *data,            int *status)                     {VStreamGetCommon                     (GET, data, status, 0, 0, node);}
-      void     streamGet                      (uint32_t *data,            int *status)                     {VStreamGetCommon                     (GET, data, status, 0, 0, node);}
-      void     streamGet                      (uint64_t *data,            int *status)                     {VStreamGetCommon                     (GET, data, status, 0, 0, node);}
+      void     streamGet                      (uint8_t  *data,            int *status)                     {VStreamUserGetCommon                     (GET, data, status, 0, 0, node);}
+      void     streamGet                      (uint16_t *data,            int *status)                     {VStreamUserGetCommon                     (GET, data, status, 0, 0, node);}
+      void     streamGet                      (uint32_t *data,            int *status)                     {VStreamUserGetCommon                     (GET, data, status, 0, 0, node);}
+      void     streamGet                      (uint64_t *data,            int *status)                     {VStreamUserGetCommon                     (GET, data, status, 0, 0, node);}
 
-      bool     streamTryGet                   (uint8_t  *data)                                             {int status; return VStreamGetCommon  (TRY_GET, data, &status, 0, 0, node);}
-      bool     streamTryGet                   (uint16_t *data)                                             {int status; return VStreamGetCommon  (TRY_GET, data, &status, 0, 0, node);}
-      bool     streamTryGet                   (uint32_t *data)                                             {int status; return VStreamGetCommon  (TRY_GET, data, &status, 0, 0, node);}
-      bool     streamTryGet                   (uint64_t *data)                                             {int status; return VStreamGetCommon  (TRY_GET, data, &status, 0, 0, node);}
+      bool     streamTryGet                   (uint8_t  *data)                                             {int status; return VStreamUserGetCommon  (TRY_GET, data, &status, 0, 0, node);}
+      bool     streamTryGet                   (uint16_t *data)                                             {int status; return VStreamUserGetCommon  (TRY_GET, data, &status, 0, 0, node);}
+      bool     streamTryGet                   (uint32_t *data)                                             {int status; return VStreamUserGetCommon  (TRY_GET, data, &status, 0, 0, node);}
+      bool     streamTryGet                   (uint64_t *data)                                             {int status; return VStreamUserGetCommon  (TRY_GET, data, &status, 0, 0, node);}
 
-      bool     streamTryGet                   (uint8_t  *data,            int *status)                     {return VStreamGetCommon              (TRY_GET, data, status, 0, 0, node);}
-      bool     streamTryGet                   (uint16_t *data,            int *status)                     {return VStreamGetCommon              (TRY_GET, data, status, 0, 0, node);}
-      bool     streamTryGet                   (uint32_t *data,            int *status)                     {return VStreamGetCommon              (TRY_GET, data, status, 0, 0, node);}
-      bool     streamTryGet                   (uint64_t *data,            int *status)                     {return VStreamGetCommon              (TRY_GET, data, status, 0, 0, node);}
+      bool     streamTryGet                   (uint8_t  *data,            int *status)                     {return VStreamUserGetCommon              (TRY_GET, data, status, 0, 0, node);}
+      bool     streamTryGet                   (uint16_t *data,            int *status)                     {return VStreamUserGetCommon              (TRY_GET, data, status, 0, 0, node);}
+      bool     streamTryGet                   (uint32_t *data,            int *status)                     {return VStreamUserGetCommon              (TRY_GET, data, status, 0, 0, node);}
+      bool     streamTryGet                   (uint64_t *data,            int *status)                     {return VStreamUserGetCommon              (TRY_GET, data, status, 0, 0, node);}
 
-      bool     streamTryCheck                 (const uint8_t  data, const int param=0)                     {int status; return VStreamGetCommon  (TRY_CHECK, null, &status, data, param, node);}
-      bool     streamTryCheck                 (const uint16_t data, const int param=0)                     {int status; return VStreamGetCommon  (TRY_CHECK, null, &status, data, param, node);}
-      bool     streamTryCheck                 (const uint32_t data, const int param=0)                     {int status; return VStreamGetCommon  (TRY_CHECK, null, &status, data, param, node);}
-      bool     streamTryCheck                 (const uint64_t data, const int param=0)                     {int status; return VStreamGetCommon  (TRY_CHECK, null, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint8_t  data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, null, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint16_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, null, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint32_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, null, &status, data, param, node);}
+      bool     streamTryCheck                 (const uint64_t data, const int param=0)                     {int status; return VStreamUserGetCommon  (TRY_CHECK, null, &status, data, param, node);}
 
-      void     streamCheck                    (const uint8_t  data, const int param=0)                     {VStreamCommon                        (CHECK, data, param, node);}
-      void     streamCheck                    (const uint16_t data, const int param=0)                     {VStreamCommon                        (CHECK, data, param, node);}
-      void     streamCheck                    (const uint32_t data, const int param=0)                     {VStreamCommon                        (CHECK, data, param, node);}
-      void     streamCheck                    (const uint64_t data, const int param=0)                     {VStreamCommon                        (CHECK, data, param, node);}
+      void     streamCheck                    (const uint8_t  data, const int param=0)                     {VStreamUserCommon                        (CHECK, data, param, node);}
+      void     streamCheck                    (const uint16_t data, const int param=0)                     {VStreamUserCommon                        (CHECK, data, param, node);}
+      void     streamCheck                    (const uint32_t data, const int param=0)                     {VStreamUserCommon                        (CHECK, data, param, node);}
+      void     streamCheck                    (const uint64_t data, const int param=0)                     {VStreamUserCommon                        (CHECK, data, param, node);}
 
-      void     streamBurstSend                (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST, BURST_NORM, data, bytesize, param, node);}
-      void     streamBurstSend                (const int bytesize,  const int param=1)                     {VStreamBurstSendCommon               (SEND_BURST, BURST_TRANS, null, bytesize, param, node);}
-      void     streamBurstSendAsync           (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST_ASYNC, BURST_NORM, data, bytesize, param, node);}
-      void     streamBurstSendAsync           (const int bytesize,  const int param=1)                     {VStreamBurstSendCommon               (SEND_BURST_ASYNC, BURST_TRANS, null, bytesize, param, node);}
+      void     streamBurstSend                (uint8_t  *data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (SEND_BURST, BURST_NORM, data, bytesize, param, node);}
+      void     streamBurstSend                (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (SEND_BURST, BURST_TRANS, null, bytesize, param, node);}
+      void     streamBurstSendAsync           (uint8_t  *data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (SEND_BURST_ASYNC, BURST_NORM, data, bytesize, param, node);}
+      void     streamBurstSendAsync           (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (SEND_BURST_ASYNC, BURST_TRANS, null, bytesize, param, node);}
 
-      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize)                   {int status; VStreamBurstGetCommon    (GET_BURST, BURST_NORM,  data, bytesize, &status, node);}
-      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize, int *status)      {VStreamBurstGetCommon                (GET_BURST, BURST_NORM,  data, bytesize, status, node);}
-      void     streamBurstGet                 (const int bytesize)                                         {int status; VStreamBurstGetCommon    (GET_BURST, BURST_TRANS, null, bytesize, &status, node);}
-      void     streamBurstGet                 (const int bytesize,        int *status)                     {VStreamBurstGetCommon                (GET_BURST, BURST_TRANS, null, bytesize, status, node);}
+      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize)                   {int status; VStreamUserBurstGetCommon    (GET_BURST, BURST_NORM,  data, bytesize, &status, node);}
+      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize, int *status)      {VStreamUserBurstGetCommon                (GET_BURST, BURST_NORM,  data, bytesize, status, node);}
+      void     streamBurstGet                 (const int bytesize)                                         {int status; VStreamUserBurstGetCommon    (GET_BURST, BURST_TRANS, null, bytesize, &status, node);}
+      void     streamBurstGet                 (const int bytesize,        int *status)                     {VStreamUserBurstGetCommon                (GET_BURST, BURST_TRANS, null, bytesize, status, node);}
 
-      void     streamBurstCheck               (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (CHECK_BURST, BURST_NORM,  data, bytesize, param, node);}
-      void     streamBurstCheck               (const int bytesize,  const int param=1)                     {VStreamBurstSendCommon               (CHECK_BURST, BURST_TRANS, null, bytesize, param, node);}
-      void     streamBurstCheckIncrement      (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param, node);}
-      void     streamBurstCheckRandom         (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param, node);}
+      void     streamBurstCheck               (uint8_t  *data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_NORM,  data, bytesize, param, node);}
+      void     streamBurstCheck               (const int bytesize,  const int param=1)                     {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_TRANS, null, bytesize, param, node);}
+      void     streamBurstCheckIncrement      (uint8_t   data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param, node);}
+      void     streamBurstCheckRandom         (uint8_t   data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param, node);}
 
-      void     streamBurstSendIncrement       (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST, BURST_INCR, &data, bytesize, param, node);}
-      void     streamBurstSendIncrementAsync  (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST_ASYNC, BURST_INCR, &data, bytesize, param, node);}
-      void     streamBurstSendRandom          (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST, BURST_RAND, &data, bytesize, param, node);}
-      void     streamBurstSendRandomAsync     (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendCommon               (SEND_BURST_ASYNC, BURST_RAND, &data, bytesize, param, node);}
+      void     streamBurstSendIncrement       (uint8_t   data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (SEND_BURST, BURST_INCR, &data, bytesize, param, node);}
+      void     streamBurstSendIncrementAsync  (uint8_t   data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (SEND_BURST_ASYNC, BURST_INCR, &data, bytesize, param, node);}
+      void     streamBurstSendRandom          (uint8_t   data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (SEND_BURST, BURST_RAND, &data, bytesize, param, node);}
+      void     streamBurstSendRandomAsync     (uint8_t   data,      const int bytesize, const int param=1) {VStreamUserBurstSendCommon               (SEND_BURST_ASYNC, BURST_RAND, &data, bytesize, param, node);}
 
-      void     streamBurstPopData             (uint8_t  *data,      const int bytesize)                    {int status; VStreamBurstGetCommon    (GET_BURST,   BURST_DATA,       data, bytesize, &status, node);}
-      void     streamBurstPushData            (uint8_t  *data,      const int bytesize)                    {VStreamBurstSendCommon               (SEND_BURST,  BURST_DATA,       data, bytesize, 0, node);}
-      void     streamBurstPushCheckData       (uint8_t  *data,      const int bytesize)                    {VStreamBurstSendCommon               (CHECK_BURST, BURST_DATA,       data, bytesize, 0, node);}
-      void     streamBurstPushIncrement       (uint8_t   data,      const int bytesize)                    {VStreamBurstSendCommon               (SEND_BURST,  BURST_INCR_PUSH, &data, bytesize, 0, node);}
-      void     streamBurstPushCheckIncrement  (uint8_t   data,      const int bytesize)                    {VStreamBurstSendCommon               (CHECK_BURST, BURST_INCR_PUSH, &data, bytesize, 0, node);}
-      void     streamBurstPushRandom          (uint8_t   data,      const int bytesize)                    {VStreamBurstSendCommon               (SEND_BURST,  BURST_RAND_PUSH, &data, bytesize, 0, node);}
-      void     streamBurstPushCheckRandom     (uint8_t   data,      const int bytesize)                    {VStreamBurstSendCommon               (CHECK_BURST, BURST_RAND_PUSH, &data, bytesize, 0, node);}
+      void     streamBurstPopData             (uint8_t  *data,      const int bytesize)                    {int status; VStreamUserBurstGetCommon    (GET_BURST,   BURST_DATA,       data, bytesize, &status, node);}
+      void     streamBurstPushData            (uint8_t  *data,      const int bytesize)                    {VStreamUserBurstSendCommon               (SEND_BURST,  BURST_DATA,       data, bytesize, 0, node);}
+      void     streamBurstPushCheckData       (uint8_t  *data,      const int bytesize)                    {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_DATA,       data, bytesize, 0, node);}
+      void     streamBurstPushIncrement       (uint8_t   data,      const int bytesize)                    {VStreamUserBurstSendCommon               (SEND_BURST,  BURST_INCR_PUSH, &data, bytesize, 0, node);}
+      void     streamBurstPushCheckIncrement  (uint8_t   data,      const int bytesize)                    {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_INCR_PUSH, &data, bytesize, 0, node);}
+      void     streamBurstPushRandom          (uint8_t   data,      const int bytesize)                    {VStreamUserBurstSendCommon               (SEND_BURST,  BURST_RAND_PUSH, &data, bytesize, 0, node);}
+      void     streamBurstPushCheckRandom     (uint8_t   data,      const int bytesize)                    {VStreamUserBurstSendCommon               (CHECK_BURST, BURST_RAND_PUSH, &data, bytesize, 0, node);}
 
-      bool     streamBurstTryGet              (const int bytesize,  const int param=1)                     {int status; return VStreamBurstGetCommon(TRY_GET_BURST,   BURST_TRANS,        null, bytesize, &status, node);}
-      bool     streamBurstTryGet              (uint8_t  *data,      const int bytesize, const int param=1) {int status; return VStreamBurstGetCommon(TRY_GET_BURST,   BURST_NORM,       data, bytesize, &status, node);}
-      bool     streamBurstTryCheck            (const int bytesize,  const int param=1)                     {return VStreamBurstSendCommon           (TRY_CHECK_BURST, BURST_TRANS,        null, bytesize, param,   node);}
-      bool     streamBurstTryCheck            (uint8_t  *data,      const int bytesize, const int param=1) {return VStreamBurstSendCommon           (TRY_CHECK_BURST, BURST_NORM,       data, bytesize, param,   node);}
-      bool     streamBurstTryCheckIncrement   (uint8_t   data,      const int bytesize, const int param=1) {return VStreamBurstSendCommon           (TRY_CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param,   node);}
-      bool     streamBurstTryCheckRandom      (uint8_t   data,      const int bytesize, const int param=1) {return VStreamBurstSendCommon           (TRY_CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param,   node);}
+      bool     streamBurstTryGet              (const int bytesize,  const int param=1)                     {int status; return VStreamUserBurstGetCommon(TRY_GET_BURST,   BURST_TRANS,        null, bytesize, &status, node);}
+      bool     streamBurstTryGet              (uint8_t  *data,      const int bytesize, const int param=1) {int status; return VStreamUserBurstGetCommon(TRY_GET_BURST,   BURST_NORM,       data, bytesize, &status, node);}
+      bool     streamBurstTryCheck            (const int bytesize,  const int param=1)                     {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_TRANS,        null, bytesize, param,   node);}
+      bool     streamBurstTryCheck            (uint8_t  *data,      const int bytesize, const int param=1) {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_NORM,       data, bytesize, param,   node);}
+      bool     streamBurstTryCheckIncrement   (uint8_t   data,      const int bytesize, const int param=1) {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param,   node);}
+      bool     streamBurstTryCheckRandom      (uint8_t   data,      const int bytesize, const int param=1) {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param,   node);}
 
       void     waitForSim                     (void)                                                       {VWaitForSim(node);}
 

--- a/code/OsvvmCosimStream.h
+++ b/code/OsvvmCosimStream.h
@@ -140,8 +140,8 @@ public:
       bool     streamBurstTryCheckIncrement   (uint8_t   data,      const int bytesize, const int param=1) {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_INCR_CHECK, &data, bytesize, param,   node);}
       bool     streamBurstTryCheckRandom      (uint8_t   data,      const int bytesize, const int param=1) {return VStreamUserBurstSendCommon           (TRY_CHECK_BURST, BURST_RAND_CHECK, &data, bytesize, param,   node);}
 
-      int      streamGetRxTransactionCount    (void)                                                       {return VStreamWaitGetCount                  (GET_TRANSACTION_COUNT, RX_REC, node);}
-      int      streamGetTxTransactionCount    (void)                                                       {return VStreamWaitGetCount                  (GET_TRANSACTION_COUNT, TX_REC, node);}
+      int      streamGetRxTransactionCount    (void)                                                       {return VStreamWaitGetCount                  (STR_GET_TRANSACTION_COUNT, RX_REC, node);}
+      int      streamGetTxTransactionCount    (void)                                                       {return VStreamWaitGetCount                  (STR_GET_TRANSACTION_COUNT, TX_REC, node);}
       void     streamWaitForRxTransaction     (void)                                                       {VStreamWaitGetCount                         (WAIT_FOR_TRANSACTION,  RX_REC, node);}
       void     streamWaitForTxTransaction     (void)                                                       {VStreamWaitGetCount                         (WAIT_FOR_TRANSACTION,  TX_REC, node);}
 

--- a/code/OsvvmCosimStream.h
+++ b/code/OsvvmCosimStream.h
@@ -62,58 +62,84 @@ public:
 #endif
       }
 
-      uint8_t  streamSend                     (const uint8_t  data, const int param=0)                {return VStreamSend(data, param, node);}
-      uint16_t streamSend                     (const uint16_t data, const int param=0)                {return VStreamSend(data, param, node);}
-      uint32_t streamSend                     (const uint32_t data, const int param=0)                {return VStreamSend(data, param, node);}
-      uint64_t streamSend                     (const uint64_t data, const int param=0)                {return VStreamSend(data, param, node);}
+      uint8_t  streamSend                     (const uint8_t  data, const int param=0)                     {return VStreamSend                   (data, param, node);}
+      uint16_t streamSend                     (const uint16_t data, const int param=0)                     {return VStreamSend                   (data, param, node);}
+      uint32_t streamSend                     (const uint32_t data, const int param=0)                     {return VStreamSend                   (data, param, node);}
+      uint64_t streamSend                     (const uint64_t data, const int param=0)                     {return VStreamSend                   (data, param, node);}
 
-      uint8_t  streamSendAsync                (const uint8_t  data, const int param=0)                {return VStreamSendAsync(data, param, node);}
-      uint16_t streamSendAsync                (const uint16_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
-      uint32_t streamSendAsync                (const uint32_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
-      uint64_t streamSendAsync                (const uint64_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
+      uint8_t  streamSendAsync                (const uint8_t  data, const int param=0)                     {return VStreamSendAsync              (data, param, node);}
+      uint16_t streamSendAsync                (const uint16_t data, const int param=0)                     {return VStreamSendAsync              (data, param, node);}
+      uint32_t streamSendAsync                (const uint32_t data, const int param=0)                     {return VStreamSendAsync              (data, param, node);}
+      uint64_t streamSendAsync                (const uint64_t data, const int param=0)                     {return VStreamSendAsync              (data, param, node);}
 
-      void     streamGet                      (uint8_t  *data)                                        {int status; VStreamGet(data, &status, node);}
-      void     streamGet                      (uint16_t *data)                                        {int status; VStreamGet(data, &status, node);}
-      void     streamGet                      (uint32_t *data)                                        {int status; VStreamGet(data, &status, node);}
-      void     streamGet                      (uint64_t *data)                                        {int status; VStreamGet(data, &status, node);}
+      void     streamGet                      (uint8_t  *data)                                             {int status; VStreamGet               (data, &status, node);}
+      void     streamGet                      (uint16_t *data)                                             {int status; VStreamGet               (data, &status, node);}
+      void     streamGet                      (uint32_t *data)                                             {int status; VStreamGet               (data, &status, node);}
+      void     streamGet                      (uint64_t *data)                                             {int status; VStreamGet               (data, &status, node);}
 
-      void     streamGet                      (uint8_t  *data, int *status)                           {VStreamGet(data, status, node);}
-      void     streamGet                      (uint16_t *data, int *status)                           {VStreamGet(data, status, node);}
-      void     streamGet                      (uint32_t *data, int *status)                           {VStreamGet(data, status, node);}
-      void     streamGet                      (uint64_t *data, int *status)                           {VStreamGet(data, status, node);}
+      void     streamGet                      (uint8_t  *data,            int *status)                     {VStreamGet                           (data, status, node);}
+      void     streamGet                      (uint16_t *data,            int *status)                     {VStreamGet                           (data, status, node);}
+      void     streamGet                      (uint32_t *data,            int *status)                     {VStreamGet                           (data, status, node);}
+      void     streamGet                      (uint64_t *data,            int *status)                     {VStreamGet                           (data, status, node);}
 
-      void     streamCheck                    (const uint8_t  data, const int param=0)                {VStreamCheck(data, param, node);}
-      void     streamCheck                    (const uint16_t data, const int param=0)                {VStreamCheck(data, param, node);}
-      void     streamCheck                    (const uint32_t data, const int param=0)                {VStreamCheck(data, param, node);}
-      void     streamCheck                    (const uint64_t data, const int param=0)                {VStreamCheck(data, param, node);}
+      bool     streamTryGet                   (uint8_t  *data)                                             {int status; return VStreamTryGet     (data, &status, node);}
+      bool     streamTryGet                   (uint16_t *data)                                             {int status; return VStreamTryGet     (data, &status, node);}
+      bool     streamTryGet                   (uint32_t *data)                                             {int status; return VStreamTryGet     (data, &status, node);}
+      bool     streamTryGet                   (uint64_t *data)                                             {int status; return VStreamTryGet     (data, &status, node);}
 
-      void     streamBurstSend                (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstSend               (data, bytesize, param, node);}
-      void     streamBurstSend                (const int bytesize, const int param=0)                 {VStreamBurstSend               (bytesize, param, node);}
-      void     streamBurstSendAsync           (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstSendAsync          (data, bytesize, param, node);}
-      void     streamBurstSendAsync           (const int bytesize, const int param=0)                 {VStreamBurstSendAsync          (bytesize, param, node);}
-      void     streamBurstGet                 (uint8_t  *data, const int bytesize)                    {int status; VStreamBurstGet    (data, bytesize, &status, node);}
-      void     streamBurstGet                 (uint8_t  *data, const int bytesize,       int *status) {VStreamBurstGet                (data, bytesize, status, node);}
-      void     streamBurstGet                 (const int bytesize)                                    {int status; VStreamBurstGet    (bytesize, &status, node);}
-      void     streamBurstGet                 (const int bytesize, int *status)                       {VStreamBurstGet                (bytesize, status, node);}
-      void     streamBurstCheck               (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstCheck              (data, bytesize, param, node);}
-      void     streamBurstCheck               (const int bytesize, const int param=0)                 {VStreamBurstCheck              (bytesize, param, node);}
-      void     streamBurstCheckIncrement      (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstCheckIncrement     (&data, bytesize, param, node);}
-      void     streamBurstCheckRandom         (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstCheckRandom        (&data, bytesize, param, node);}
-      void     streamBurstSendIncrement       (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendIncrement      (&data, bytesize, param, node);}
-      void     streamBurstSendIncrementAsync  (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendIncrementAsync (&data, bytesize, param, node);}
-      void     streamBurstSendRandom          (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendRandom         (&data, bytesize, param, node);}
-      void     streamBurstSendRandomAsync     (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendRandomAsync    (&data, bytesize, param, node);}
-      void     streamBurstPopData             (uint8_t  *data, const int bytesize)                    {VStreamBurstPopData            (data,  bytesize, node);}
-      void     streamBurstPushData            (uint8_t  *data, const int bytesize)                    {VStreamBurstPushData           (data,  bytesize, node);}
-      void     streamBurstPushCheckData       (uint8_t  *data, const int bytesize)                    {VStreamBurstPushCheckData      (data,  bytesize, node);}
-      void     streamBurstPushIncrement       (uint8_t   data, const int bytesize)                    {VStreamBurstPushIncrement      (&data, bytesize, node);}
-      void     streamBurstPushCheckIncrement  (uint8_t   data, const int bytesize)                    {VStreamBurstPushCheckIncrement (&data, bytesize, node);}
-      void     streamBurstPushRandom          (uint8_t   data, const int bytesize)                    {VStreamBurstPushRandom         (&data, bytesize, node);}
-      void     streamBurstPushCheckRandom     (uint8_t   data, const int bytesize)                    {VStreamBurstPushCheckRandom    (&data, bytesize, node);}
+      bool     streamTryGet                   (uint8_t  *data,            int *status)                     {return VStreamTryGet                 (data, status, node);}
+      bool     streamTryGet                   (uint16_t *data,            int *status)                     {return VStreamTryGet                 (data, status, node);}
+      bool     streamTryGet                   (uint32_t *data,            int *status)                     {return VStreamTryGet                 (data, status, node);}
+      bool     streamTryGet                   (uint64_t *data,            int *status)                     {return VStreamTryGet                 (data, status, node);}
 
-      void     waitForSim                     (void)                                                   {VWaitForSim(node);}
+      bool     streamTryCheck                 (const uint8_t  data, const int param=0)                     {return VStreamTryCheck               (data, param, node);}
+      bool     streamTryCheck                 (const uint16_t data, const int param=0)                     {return VStreamTryCheck               (data, param, node);}
+      bool     streamTryCheck                 (const uint32_t data, const int param=0)                     {return VStreamTryCheck               (data, param, node);}
+      bool     streamTryCheck                 (const uint64_t data, const int param=0)                     {return VStreamTryCheck               (data, param, node);}
 
-      int      getNodeNumber                  (void)                                                   {return node;}
+      void     streamCheck                    (const uint8_t  data, const int param=0)                     {VStreamCheck                         (data, param, node);}
+      void     streamCheck                    (const uint16_t data, const int param=0)                     {VStreamCheck                         (data, param, node);}
+      void     streamCheck                    (const uint32_t data, const int param=0)                     {VStreamCheck                         (data, param, node);}
+      void     streamCheck                    (const uint64_t data, const int param=0)                     {VStreamCheck                         (data, param, node);}
+
+      void     streamBurstSend                (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSend                     (data, bytesize, param, node);}
+      void     streamBurstSend                (const int bytesize,  const int param=1)                     {VStreamBurstSend                     (bytesize, param, node);}
+      void     streamBurstSendAsync           (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstSendAsync                (data, bytesize, param, node);}
+      void     streamBurstSendAsync           (const int bytesize,  const int param=1)                     {VStreamBurstSendAsync                (bytesize, param, node);}
+
+      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize)                   {int status; VStreamBurstGet          (data, bytesize, &status, node);}
+      void     streamBurstGet                 (uint8_t  *data,      const int  bytesize, int *status)      {VStreamBurstGet                      (data, bytesize, status, node);}
+      void     streamBurstGet                 (const int bytesize)                                         {int status; VStreamBurstGet          (bytesize, &status, node);}
+      void     streamBurstGet                 (const int bytesize,        int *status)                     {VStreamBurstGet                      (bytesize, status, node);}
+
+      void     streamBurstCheck               (uint8_t  *data,      const int bytesize, const int param=1) {VStreamBurstCheck                    (data, bytesize, param, node);}
+      void     streamBurstCheck               (const int bytesize,  const int param=1)                     {VStreamBurstCheck                    (bytesize, param, node);}
+      void     streamBurstCheckIncrement      (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstCheckIncrement           (&data, bytesize, param, node);}
+      void     streamBurstCheckRandom         (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstCheckRandom              (&data, bytesize, param, node);}
+
+      void     streamBurstSendIncrement       (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendIncrement            (&data, bytesize, param, node);}
+      void     streamBurstSendIncrementAsync  (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendIncrementAsync       (&data, bytesize, param, node);}
+      void     streamBurstSendRandom          (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendRandom               (&data, bytesize, param, node);}
+      void     streamBurstSendRandomAsync     (uint8_t   data,      const int bytesize, const int param=1) {VStreamBurstSendRandomAsync          (&data, bytesize, param, node);}
+
+      void     streamBurstPopData             (uint8_t  *data,      const int bytesize)                    {VStreamBurstPopData                  (data,  bytesize, node);}
+      void     streamBurstPushData            (uint8_t  *data,      const int bytesize)                    {VStreamBurstPushData                 (data,  bytesize, node);}
+      void     streamBurstPushCheckData       (uint8_t  *data,      const int bytesize)                    {VStreamBurstPushCheckData            (data,  bytesize, node);}
+      void     streamBurstPushIncrement       (uint8_t   data,      const int bytesize)                    {VStreamBurstPushIncrement            (&data, bytesize, node);}
+      void     streamBurstPushCheckIncrement  (uint8_t   data,      const int bytesize)                    {VStreamBurstPushCheckIncrement       (&data, bytesize, node);}
+      void     streamBurstPushRandom          (uint8_t   data,      const int bytesize)                    {VStreamBurstPushRandom               (&data, bytesize, node);}
+      void     streamBurstPushCheckRandom     (uint8_t   data,      const int bytesize)                    {VStreamBurstPushCheckRandom          (&data, bytesize, node);}
+
+      bool     streamBurstTryGet              (const int bytesize,  const int param=1)                     {return VStreamBurstTryGet            (bytesize, param, node);}
+      bool     streamBurstTryGet              (uint8_t  *data,      const int bytesize, const int param=1) {return VStreamBurstTryGet            (data, bytesize, param, node);}
+      bool     streamBurstTryCheck            (const int bytesize,  const int param=1)                     {return VStreamBurstTryCheck          (bytesize, param, node);}
+      bool     streamBurstTryCheck            (uint8_t  *data,      const int bytesize, const int param=1) {return VStreamBurstTryCheck          (data, bytesize, param, node);}
+      bool     streamBurstTryCheckIncrement   (uint8_t   data,      const int bytesize, const int param=1) {return VStreamBurstTryCheckIncrement (&data, bytesize, param, node);}
+      bool     streamBurstTryCheckRandom      (uint8_t   data,      const int bytesize, const int param=1) {return VStreamBurstTryCheckRandom    (&data, bytesize, param, node);}
+
+      void     waitForSim                     (void)                                                       {VWaitForSim(node);}
+
+      int      getNodeNumber                  (void)                                                       {return node;}
 
 private:
 

--- a/code/OsvvmCosimStream.h
+++ b/code/OsvvmCosimStream.h
@@ -62,33 +62,45 @@ public:
 #endif
       }
 
-      uint8_t  streamSend           (const uint8_t  data, const int param=0) {return VStreamSend(data, param, node);}
-      uint16_t streamSend           (const uint16_t data, const int param=0) {return VStreamSend(data, param, node);}
-      uint32_t streamSend           (const uint32_t data, const int param=0) {return VStreamSend(data, param, node);}
-      uint64_t streamSend           (const uint64_t data, const int param=0) {return VStreamSend(data, param, node);}
+      uint8_t  streamSend               (const uint8_t  data, const int param=0)                {return VStreamSend(data, param, node);}
+      uint16_t streamSend               (const uint16_t data, const int param=0)                {return VStreamSend(data, param, node);}
+      uint32_t streamSend               (const uint32_t data, const int param=0)                {return VStreamSend(data, param, node);}
+      uint64_t streamSend               (const uint64_t data, const int param=0)                {return VStreamSend(data, param, node);}
+                                        
+      uint8_t  streamSendAsync          (const uint8_t  data, const int param=0)                {return VStreamSendAsync(data, param, node);}
+      uint16_t streamSendAsync          (const uint16_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
+      uint32_t streamSendAsync          (const uint32_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
+      uint64_t streamSendAsync          (const uint64_t data, const int param=0)                {return VStreamSendAsync(data, param, node);}
+                                        
+      void     streamGet                (uint8_t  *data)                                        {int status; VStreamGet(data, &status, node);}
+      void     streamGet                (uint16_t *data)                                        {int status; VStreamGet(data, &status, node);}
+      void     streamGet                (uint32_t *data)                                        {int status; VStreamGet(data, &status, node);}
+      void     streamGet                (uint64_t *data)                                        {int status; VStreamGet(data, &status, node);}
+                                        
+      void     streamGet                (uint8_t  *data, int *status)                           {VStreamGet(data, status, node);}
+      void     streamGet                (uint16_t *data, int *status)                           {VStreamGet(data, status, node);}
+      void     streamGet                (uint32_t *data, int *status)                           {VStreamGet(data, status, node);}
+      void     streamGet                (uint64_t *data, int *status)                           {VStreamGet(data, status, node);}
+                                        
+      void     streamCheck              (const uint8_t  data, const int param=0)                {VStreamCheck(data, param, node);}
+      void     streamCheck              (const uint16_t data, const int param=0)                {VStreamCheck(data, param, node);}
+      void     streamCheck              (const uint32_t data, const int param=0)                {VStreamCheck(data, param, node);}
+      void     streamCheck              (const uint64_t data, const int param=0)                {VStreamCheck(data, param, node);}
+                                        
+      void     streamBurstSend          (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstSend      (data, bytesize, param, node);}
+      void     streamBurstSendAsync     (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstSendAsync (data, bytesize, param, node);}
+      void     streamBurstGet           (uint8_t  *data, const int bytesize)                    {int status; VStreamBurstGet (data, bytesize, &status, node);}
+      void     streamBurstGet           (uint8_t  *data, const int bytesize,       int *status) {VStreamBurstGet       (data, bytesize, status, node);}
+      void     streamBurstGet           (const int bytesize)                                    {int status; VStreamBurstGet (bytesize, &status, node);}
+      void     streamBurstGet           (const int bytesize, int *status)                       {VStreamBurstGet       (bytesize, status, node);}
+      void     streamBurstCheck         (uint8_t  *data, const int bytesize, const int param=0) {VStreamBurstCheck     (data, bytesize, param, node);}
+      void     streamBurstSendIncrement (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendIncrement(&data, bytesize, param, node);}
+      void     streamBurstSendRandom    (uint8_t   data, const int bytesize, const int param=0) {VStreamBurstSendRandom(&data, bytesize, param, node);}
+      void     streamBurstPopData       (uint8_t  *data, const int bytesize)                    {VStreamBurstPopData   (data, bytesize, node);}
 
-      uint8_t  streamSendAsync      (const uint8_t  data, const int param=0) {return VStreamSendAsync(data, param, node);}
-      uint16_t streamSendAsync      (const uint16_t data, const int param=0) {return VStreamSendAsync(data, param, node);}
-      uint32_t streamSendAsync      (const uint32_t data, const int param=0) {return VStreamSendAsync(data, param, node);}
-      uint64_t streamSendAsync      (const uint64_t data, const int param=0) {return VStreamSendAsync(data, param, node);}
+      void     waitForSim              (void)                                                  {VWaitForSim(node);}
 
-      void     streamGet            (uint8_t  *data)                         {int status; VStreamGet(data, &status, node);}
-      void     streamGet            (uint16_t *data)                         {int status; VStreamGet(data, &status, node);}
-      void     streamGet            (uint32_t *data)                         {int status; VStreamGet(data, &status, node);}
-      void     streamGet            (uint64_t *data)                         {int status; VStreamGet(data, &status, node);}
-
-      void     streamGet            (uint8_t  *data, int *status)            {VStreamGet(data, status, node);}
-      void     streamGet            (uint16_t *data, int *status)            {VStreamGet(data, status, node);}
-      void     streamGet            (uint32_t *data, int *status)            {VStreamGet(data, status, node);}
-      void     streamGet            (uint64_t *data, int *status)            {VStreamGet(data, status, node);}
-
-      void     streamBurstSend      (uint8_t  *data, const int bytesize)     {VStreamBurstSend      (data, bytesize, node);}
-      void     streamBurstSendAsync (uint8_t  *data, const int bytesize)     {VStreamBurstSendAsync (data, bytesize, node);}
-      void     streamBurstGet       (uint8_t  *data, const int bytesize)     {VStreamBurstGet       (data, bytesize, node);}
-
-      void     waitForSim           (void)                                   {VWaitForSim(node);}
-
-      int      getNodeNumber        (void)                                   {return node;}
+      int      getNodeNumber           (void)                                                  {return node;}
 
 private:
 

--- a/code/OsvvmVProc.h
+++ b/code/OsvvmVProc.h
@@ -43,7 +43,7 @@
 #include <stdlib.h>
 #include <strings.h>
 
-# if !defined(ALDEC)
+# if !defined(ALDEC) || !defined(_WIN32)
 #  ifndef __USE_GNU
 #  define __USE_GNU
 #  include <dlfcn.h>

--- a/code/OsvvmVProc.h
+++ b/code/OsvvmVProc.h
@@ -170,7 +170,7 @@ typedef enum stream_operation_e
     //NOT_DRIVEN = 0,
     //WAIT_FOR_CLOCK,
     //WAIT_FOR_TRANSACTION,
-    //GET_TRANSACTION_COUNT,
+    STR_GET_TRANSACTION_COUNT = 3,
     //GET_ALERTLOG_ID,
     //SET_BURST_MODE,
     //GET_BURST_MODE,

--- a/code/OsvvmVProc.h
+++ b/code/OsvvmVProc.h
@@ -204,7 +204,9 @@ typedef enum burst_write_type_e
     BURST_INCR_PUSH,
     BURST_RAND_PUSH,
     BURST_INCR_CHECK,
-    BURST_RAND_CHECK
+    BURST_RAND_CHECK,
+    BURST_TRANS,
+    BURST_DATA,
 } burst_type_t;
 
 typedef struct

--- a/code/OsvvmVProc.h
+++ b/code/OsvvmVProc.h
@@ -162,7 +162,9 @@ typedef enum addr_bus_trans_op_e
     READ_BURST,
     MULTIPLE_DRIVER_DETECT,
 
-    SET_TEST_NAME = 1024
+    SET_TEST_NAME = 1024,
+    PUSH_BURST_INCR,
+    PUSH_BURST_RAND
 } addr_bus_trans_op_t;
 
 typedef enum stream_operation_e
@@ -194,12 +196,13 @@ typedef enum stream_operation_e
     //SET_TEST_NAME = 1024
 } stream_operation_t;
 
-typedef enum arch_e
+typedef enum burst_write_type_e
 {
-    arch32,
-    arch64,
-    arch128
-} arch_e;
+    BURST_NORM,
+    BURST_INCR,
+    BURST_RAND
+    
+} burst_write_type_t;
 
 typedef struct
 {

--- a/code/OsvvmVProc.h
+++ b/code/OsvvmVProc.h
@@ -15,12 +15,14 @@
 //
 //  Revision History:
 //    Date      Version    Description
-//    10/2022   2023.01    Initial revision
+//    05/2023   2023.05    Adding asynchronous transaction support
+//    03/2023   2023.04    Adding basic stream support
+//    01/2023   2023.01    Initial revision
 //
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -38,6 +40,10 @@
 
 #ifndef _OSVVM_VPROC_H_
 #define _OSVVM_VPROC_H_
+
+// -------------------------------------------------------------------------
+// INCLUDES
+// -------------------------------------------------------------------------
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,16 +70,13 @@
 // For inode manipulation
 #include <unistd.h>
 
+// -------------------------------------------------------------------------
+// DEFINES AND MACROS
+// -------------------------------------------------------------------------
+
 #ifndef VP_MAX_NODES
 #define VP_MAX_NODES            64
 #endif
-
-
-#define V_IDLE                  0
-#define V_WRITE                 1
-#define V_READ                  2
-#define V_HALT                  4
-#define V_SWAP                  8
 
 #define VP_EXIT_OK              0
 #define VP_QUEUE_ERR            1
@@ -81,57 +84,43 @@
 #define VP_USER_ERR             3
 #define VP_SYSCALL_ERR          4
 
-#define UNDEF                   -1
 
 #define DEFAULT_STR_BUF_SIZE    32
-
-#define MIN_INTERRUPT_LEVEL     1
-#define MAX_INTERRUPT_LEVEL     255
-
 #define DATABUF_SIZE            4096
 
+// -------------------------------------------------------------------------
+// TYPEDEFS
+// -------------------------------------------------------------------------
 
 typedef enum trans_type_e
 {
-  trans32_wr_byte  = 0,
-  trans32_wr_hword,
-  trans32_wr_word,
-  trans32_wr_dword,
-  trans32_wr_qword,
-  trans32_wr_burst,
-  trans32_rd_byte,
-  trans32_rd_hword,
-  trans32_rd_word ,
-  trans32_rd_dword,
-  trans32_rd_qword,
-  trans32_rd_burst,
-  trans64_wr_byte,
-  trans64_wr_hword,
-  trans64_wr_word,
-  trans64_wr_dword,
-  trans64_wr_qword,
-  trans64_wr_burst,
-  trans64_rd_byte,
-  trans64_rd_hword,
-  trans64_rd_word,
-  trans64_rd_dword,
-  trans64_rd_qword,
-  trans64_rd_burst,
-  
-  stream_snd_byte,
-  stream_snd_hword,
-  stream_snd_word,
-  stream_snd_dword,
-  stream_snd_qword,
-  stream_snd_burst,
-  stream_get_byte,
-  stream_get_hword,
-  stream_get_word,
-  stream_get_dword,
-  stream_get_qword,
-  stream_get_burst,
-  
-  trans_idle
+    trans32_byte  = 0,
+    trans32_hword,
+    trans32_word,
+    trans32_dword,
+    trans32_qword,
+    trans32_burst,
+    trans64_byte,
+    trans64_hword,
+    trans64_word,
+    trans64_dword,
+    trans64_qword,
+    trans64_burst,
+
+    stream_snd_byte,
+    stream_snd_hword,
+    stream_snd_word,
+    stream_snd_dword,
+    stream_snd_qword,
+    stream_snd_burst,
+    stream_get_byte,
+    stream_get_hword,
+    stream_get_word,
+    stream_get_dword,
+    stream_get_qword,
+    stream_get_burst,
+
+    trans_idle
 
 } trans_type_e;
 
@@ -172,36 +161,36 @@ typedef enum addr_bus_trans_op_e
     ASYNC_WRITE_BURST,
     READ_BURST,
     MULTIPLE_DRIVER_DETECT,
-    
+
     SET_TEST_NAME = 1024
 } addr_bus_trans_op_t;
 
 typedef enum stream_operation_e
 {
-    //NOT_DRIVEN = 0,  
-    //WAIT_FOR_CLOCK, 
+    //NOT_DRIVEN = 0,
+    //WAIT_FOR_CLOCK,
     //WAIT_FOR_TRANSACTION,
     //GET_TRANSACTION_COUNT,
     //GET_ALERTLOG_ID,
     //SET_BURST_MODE,
     //GET_BURST_MODE,
-    //GOT_BURST, 
+    //GOT_BURST,
     //SET_MODEL_OPTIONS,
     //GET_MODEL_OPTIONS,
-    SEND = 10,                // This first (cf. write)
+    SEND = 10,
     SEND_ASYNC,
-    SEND_BURST,          // This first (cf. write burst)
+    SEND_BURST,
     SEND_BURST_ASYNC,
-    GET,                 // This first (cf. read)    
+    GET,
     TRY_GET,
-    GET_BURST,           // This first (cf. read burst)
+    GET_BURST,
     TRY_GET_BURST,
     CHECK,
     TRY_CHECK,
     CHECK_BURST,
     TRY_CHECK_BURST,
     //MULTIPLE_DRIVER_DETECT,
-    
+
     //SET_TEST_NAME = 1024
 } stream_operation_t;
 

--- a/code/OsvvmVProc.h
+++ b/code/OsvvmVProc.h
@@ -200,9 +200,12 @@ typedef enum burst_write_type_e
 {
     BURST_NORM,
     BURST_INCR,
-    BURST_RAND
-    
-} burst_write_type_t;
+    BURST_RAND,
+    BURST_INCR_PUSH,
+    BURST_RAND_PUSH,
+    BURST_INCR_CHECK,
+    BURST_RAND_CHECK
+} burst_type_t;
 
 typedef struct
 {

--- a/code/OsvvmVProc.h
+++ b/code/OsvvmVProc.h
@@ -162,9 +162,7 @@ typedef enum addr_bus_trans_op_e
     READ_BURST,
     MULTIPLE_DRIVER_DETECT,
 
-    SET_TEST_NAME = 1024,
-    PUSH_BURST_INCR,
-    PUSH_BURST_RAND
+    SET_TEST_NAME = 1024
 } addr_bus_trans_op_t;
 
 typedef enum stream_operation_e
@@ -231,6 +229,8 @@ typedef struct
     int                 num_burst_bytes;
     uint8_t             databuf[DATABUF_SIZE];
     int                 status;
+    int                 count;
+    int                 countsec;
     unsigned int        interrupt;
 } rcv_buf_t, *prcv_buf_t;
 

--- a/code/OsvvmVProc.h
+++ b/code/OsvvmVProc.h
@@ -226,6 +226,8 @@ typedef struct
 {
     unsigned int        data_in;
     unsigned int        data_in_hi;
+    unsigned int        addr_in;
+    unsigned int        addr_in_hi;
     int                 num_burst_bytes;
     uint8_t             databuf[DATABUF_SIZE];
     int                 status;

--- a/code/OsvvmVSched.c
+++ b/code/OsvvmVSched.c
@@ -253,10 +253,21 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
     VPDone_int           = 0;
     VPError_int          = 0;
     VPParam_int          = 0;
-
+    
+    // Skip over data outputs
+    argIdx               += 3;
+    
+    // Sample address and update node receive state
+    ns[node]->rcv_buf.addr_in    = args[argIdx++];
+    ns[node]->rcv_buf.addr_in_hi = args[argIdx++];
+    
+#else
+    // Sample Address and update node receive state
+    ns[node]->rcv_buf.addr_in    = *VPAddr;
+    ns[node]->rcv_buf.addr_in_hi = *VPAddrHi;
 #endif
 
-    // Sample inputs and update node state
+    // Sample data inputs and update node receive state
     if (ns[node]->send_buf.type != trans32_burst)
     {
         ns[node]->rcv_buf.data_in    = VPDataIn;
@@ -266,12 +277,14 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
     {
         ns[node]->rcv_buf.num_burst_bytes = ns[node]->send_buf.num_burst_bytes;
     }
+    
+    // Sample other inputs and update node receive state
     ns[node]->rcv_buf.interrupt  = Interrupt;
     ns[node]->rcv_buf.status     = VPStatus;
     ns[node]->rcv_buf.count      = VPCount;
     ns[node]->rcv_buf.countsec   = VPCountSec;
 
-    // Send message to VUser with VPDataIn value
+    // Send message to VUser with input values
     DebugVPrint("VTrans(): setting rcv[%d] semaphore\n", node);
     sem_post(&(ns[node]->rcv));
 

--- a/code/OsvvmVSched.c
+++ b/code/OsvvmVSched.c
@@ -216,6 +216,8 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
     int  node;
     int  Interrupt;
     int  VPStatus;
+    int  VPCount;
+    int  VPCountSec;
     int  VPDataIn;
     int  VPDataInHi;
     int* VPDataOut;
@@ -237,6 +239,8 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
     node                 = args[argIdx++];
     Interrupt            = args[argIdx++];
     VPStatus             = args[argIdx++];
+    VPCount              = args[argIdx++];
+    VPCountSec           = args[argIdx++];
     VPDataIn             = args[argIdx++]; VPDataInHi     = args[argIdx++];
 
     VPDataOut_int        = 0; VPDataOut_int  = 0;
@@ -264,6 +268,8 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
     }
     ns[node]->rcv_buf.interrupt  = Interrupt;
     ns[node]->rcv_buf.status     = VPStatus;
+    ns[node]->rcv_buf.count      = VPCount;
+    ns[node]->rcv_buf.countsec   = VPCountSec;
 
     // Send message to VUser with VPDataIn value
     DebugVPrint("VTrans(): setting rcv[%d] semaphore\n", node);

--- a/code/OsvvmVSched.c
+++ b/code/OsvvmVSched.c
@@ -1,6 +1,6 @@
 // =========================================================================
 //
-//  File Name:         OsvvmVProc.h
+//  File Name:         OsvvmSched.c
 //  Design Unit Name:
 //  Revision:          OSVVM MODELS STANDARD VERSION
 //
@@ -15,13 +15,14 @@
 //
 //  Revision History:
 //    Date      Version    Description
-//    02/2023   2023.??    Added support from streaming
-//    10/2022   2023.01    Initial revision
+//    05/2023   2023.05    Adding asynchronous transaction support
+//    03/2023   2023.04    Adding basic stream support
+//    01/2023   2023.01    Initial revision
 //
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -252,7 +253,7 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
 #endif
 
     // Sample inputs and update node state
-    if (ns[node]->send_buf.type != trans32_rd_burst && ns[node]->send_buf.type != trans32_wr_burst)
+    if (ns[node]->send_buf.type != trans32_burst)
     {
         ns[node]->rcv_buf.data_in    = VPDataIn;
         ns[node]->rcv_buf.data_in_hi = VPDataInHi;
@@ -288,58 +289,43 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
 
         switch(ns[node]->send_buf.type)
         {
-            case trans32_wr_byte:
-            case trans32_rd_byte:
+            case trans32_byte:
                 VPAddrWidth_int = 32;
                 VPDataWidth_int = 8;
                 break;
-            case trans32_wr_hword:
-            case trans32_rd_hword:
+            case trans32_hword:
                 VPAddrWidth_int = 32;
                 VPDataWidth_int = 16;
                 break;
-            case trans32_wr_word:
-            case trans32_rd_word:
+            case trans32_word:
+            case trans32_burst:
                 VPAddrWidth_int = 32;
                 VPDataWidth_int = 32;
                 break;
-            case trans32_wr_burst:
-            case trans32_rd_burst:
-                VPAddrWidth_int = 32;
-                VPDataWidth_int = 32;
-                break;
+            case trans64_byte:
             case stream_snd_byte:
             case stream_get_byte:
-            case trans64_wr_byte:
-            case trans64_rd_byte:
                 VPAddrWidth_int = 64;
                 VPDataWidth_int = 8;
                 break;
+            case trans64_hword:
             case stream_snd_hword:
             case stream_get_hword:
-            case trans64_wr_hword:
-            case trans64_rd_hword:
                 VPAddrWidth_int = 64;
                 VPDataWidth_int = 16;
                 break;
+            case trans64_word:
             case stream_snd_word:
             case stream_get_word:
-            case trans64_wr_word:
-            case trans64_rd_word:
                 VPAddrWidth_int = 64;
                 VPDataWidth_int = 32;
                 break;
+            case trans64_dword:
             case stream_snd_dword:
             case stream_get_dword:
-            case trans64_wr_dword:
-            case trans64_rd_dword:
-                VPAddrWidth_int = 64;
-                VPDataWidth_int = 64;
-                break ;
             case stream_snd_burst:
             case stream_get_burst:
-            case trans64_wr_burst:
-            case trans64_rd_burst:
+            case trans64_burst:
                 VPAddrWidth_int = 64;
                 VPDataWidth_int = 64;
                 break;

--- a/code/OsvvmVSchedPli.h
+++ b/code/OsvvmVSchedPli.h
@@ -15,6 +15,7 @@
 //
 //  Revision History:
 //    Date      Version    Description
+//    05/2023   2023.05    Refactored VTrans arguments
 //    10/2022   2023.01    Initial revision
 //
 //
@@ -41,11 +42,17 @@
 #ifndef _OSVVM_VSCHED_PLI_H_
 #define _OSVVM_VSCHED_PLI_H_
 
+#ifdef __cplusplus
+#define LINKAGE "C"
+#else
+#define LINKAGE
+#endif
+
 #ifndef ALDEC
 
 #define VINIT_PARAMS               int  node
 #define VTRANS_PARAMS              int  node,     int  Interrupt,   int  VPStatus,    int  VPCount,     int  VPCountSec,  \
-                                   int  VPDataIn, int  VPDataInHi,  int* VPDataOut,   int* VPDataOutHi, int* VPDataWidth, \
+                                   int* VPData,   int* VPDataHi,    int* VPDataWidth,                                     \
                                    int* VPAddr,   int* VPAddrHi,    int* VPAddrWidth,                                     \
                                    int* VPOp,     int* VPBurstSize, int* VPTicks,     int* VPDone,      int* VPError,     \
                                    int* VPParam
@@ -65,20 +72,20 @@
 #define VSETBURSTRDBYTE_PARAMS              const struct vhpiCbDataS* cb
 
 #define VINIT_NUM_ARGS                      1
-#define VTRANS_NUM_ARGS                     19
+#define VTRANS_NUM_ARGS                     17
 #define VGETBURSTWRBYTE_NUM_ARGS            3
 #define VSETBURSTRDBYTE_NUM_ARGS            3
                                             
-#define VTRANS_START_OF_OUTPUTS             7
+#define VTRANS_START_OF_OUTPUTS             5
 #define VGETBURSTWRBYTE_START_OF_OUTPUTS    2
 
 #define VPROC_RTN_TYPE                      PLI_VOID
 
 #endif
 
-extern VPROC_RTN_TYPE VInit           (VINIT_PARAMS);
-extern VPROC_RTN_TYPE VTrans          (VTRANS_PARAMS);
-extern VPROC_RTN_TYPE VSetBurstRdByte (VSETBURSTRDBYTE_PARAMS);
-extern VPROC_RTN_TYPE VGetBurstWrByte (VGETBURSTWRBYTE_PARAMS);
+extern LINKAGE VPROC_RTN_TYPE VInit           (VINIT_PARAMS);
+extern LINKAGE VPROC_RTN_TYPE VTrans          (VTRANS_PARAMS);
+extern LINKAGE VPROC_RTN_TYPE VSetBurstRdByte (VSETBURSTRDBYTE_PARAMS);
+extern LINKAGE VPROC_RTN_TYPE VGetBurstWrByte (VGETBURSTWRBYTE_PARAMS);
 
 #endif

--- a/code/OsvvmVSchedPli.h
+++ b/code/OsvvmVSchedPli.h
@@ -44,7 +44,7 @@
 #ifndef ALDEC
 
 #define VINIT_PARAMS               int  node
-#define VTRANS_PARAMS              int  node,     int  Interrupt,   int  VPStatus,                                        \
+#define VTRANS_PARAMS              int  node,     int  Interrupt,   int  VPStatus,    int  VPCount,     int  VPCountSec,  \
                                    int  VPDataIn, int  VPDataInHi,  int* VPDataOut,   int* VPDataOutHi, int* VPDataWidth, \
                                    int* VPAddr,   int* VPAddrHi,    int* VPAddrWidth,                                     \
                                    int* VPOp,     int* VPBurstSize, int* VPTicks,     int* VPDone,      int* VPError,     \
@@ -65,11 +65,11 @@
 #define VSETBURSTRDBYTE_PARAMS              const struct vhpiCbDataS* cb
 
 #define VINIT_NUM_ARGS                      1
-#define VTRANS_NUM_ARGS                     17
+#define VTRANS_NUM_ARGS                     19
 #define VGETBURSTWRBYTE_NUM_ARGS            3
 #define VSETBURSTRDBYTE_NUM_ARGS            3
                                             
-#define VTRANS_START_OF_OUTPUTS             5
+#define VTRANS_START_OF_OUTPUTS             7
 #define VGETBURSTWRBYTE_START_OF_OUTPUTS    2
 
 #define VPROC_RTN_TYPE                      PLI_VOID

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -854,9 +854,12 @@ static void VStreamBurstSendCommon (const stream_operation_t op, const int burst
     sbuf.param              = param;
     *((uint32_t*)sbuf.data) = burst_type; // Re-use data field of send buffer for burst sub-operation
 
-    for (int idx = 0; idx < sbuf.num_burst_bytes; idx++)
+    if (burst_type != BURST_TRANS)
     {
-        sbuf.databuf[idx] = data[idx];
+        for (int idx = 0; idx < sbuf.num_burst_bytes; idx++)
+        {
+            sbuf.databuf[idx] = data[idx];
+        }
     }
 
     VExch(&sbuf, &rbuf, node);
@@ -1559,9 +1562,19 @@ void VStreamBurstSend (uint8_t* data, const int bytesize, const int param, const
     VStreamBurstSendCommon(SEND_BURST, BURST_NORM, data, bytesize, param, node);
 }
 
+void VStreamBurstSend (const int bytesize, const int param, const uint32_t node)
+{
+    VStreamBurstSendCommon(SEND_BURST, BURST_TRANS, null, bytesize, param, node);
+}
+
 void VStreamBurstSendAsync (uint8_t* data, const int bytesize, const int param, const uint32_t node)
 {
     VStreamBurstSendCommon(SEND_BURST_ASYNC, BURST_NORM, data, bytesize, param, node);
+}
+
+void VStreamBurstSendAsync (const int bytesize, const int param, const uint32_t node)
+{
+    VStreamBurstSendCommon(SEND_BURST_ASYNC, BURST_TRANS, null, bytesize, param, node);
 }
 
 void VStreamBurstCheck (uint8_t* data, const int bytesize, const int param, const uint32_t node)
@@ -1569,14 +1582,39 @@ void VStreamBurstCheck (uint8_t* data, const int bytesize, const int param, cons
     VStreamBurstSendCommon(CHECK_BURST, BURST_NORM, data, bytesize, param, node);
 }
 
+void VStreamBurstCheck (const int bytesize, const int param, const uint32_t node)
+{
+    VStreamBurstSendCommon(CHECK_BURST, BURST_TRANS, null, bytesize, param, node);
+}
+
 void VStreamBurstSendIncrement (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
 {
-    VStreamBurstSendCommon(CHECK_BURST, BURST_INCR, data, bytesize, param, node);
+    VStreamBurstSendCommon(SEND_BURST, BURST_INCR, data, bytesize, param, node);
+}
+
+void VStreamBurstSendIncrementAsync (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
+{
+    VStreamBurstSendCommon(SEND_BURST_ASYNC, BURST_INCR, data, bytesize, param, node);
+}
+
+void VStreamBurstCheckIncrement (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
+{
+    VStreamBurstSendCommon(CHECK_BURST, BURST_INCR_CHECK, data, bytesize, param, node);
 }
 
 void VStreamBurstSendRandom (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
 {
     VStreamBurstSendCommon(CHECK_BURST, BURST_RAND, data, bytesize, param, node);
+}
+
+void VStreamBurstSendRandomAsync (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
+{
+    VStreamBurstSendCommon(SEND_BURST_ASYNC, BURST_RAND, data, bytesize, param, node);
+}
+
+void VStreamBurstCheckRandom (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
+{
+    VStreamBurstSendCommon(CHECK_BURST, BURST_RAND_CHECK, data, bytesize, param, node);
 }
 
 void VStreamBurstGet (uint8_t* data, const int bytesize, int* status, const uint32_t node)
@@ -1595,3 +1633,40 @@ void VStreamBurstPopData(uint8_t* data, const int bytesize, const uint32_t node)
     
     VStreamBurstGetCommon(GET_BURST, BURST_DATA, data, bytesize, &status, node);
 }
+
+void VStreamBurstPushData(uint8_t* data, const int bytesize, const uint32_t node)
+{
+    
+    VStreamBurstSendCommon(SEND_BURST, BURST_DATA, data, bytesize, 0, node);
+}
+
+void VStreamBurstPushCheckData(uint8_t* data, const int bytesize, const uint32_t node)
+{
+    
+    VStreamBurstSendCommon(CHECK_BURST, BURST_DATA, data, bytesize, 0, node);
+}
+
+void VStreamBurstPushIncrement(uint8_t* data, const int bytesize, const uint32_t node)
+{
+    
+    VStreamBurstSendCommon(SEND_BURST, BURST_INCR_PUSH, data, bytesize, 0, node);
+}
+
+void VStreamBurstPushCheckIncrement(uint8_t* data, const int bytesize, const uint32_t node)
+{
+    
+    VStreamBurstSendCommon(CHECK_BURST, BURST_INCR_PUSH, data, bytesize, 0, node);
+}
+
+void VStreamBurstPushRandom(uint8_t* data, const int bytesize, const uint32_t node)
+{
+    
+    VStreamBurstSendCommon(SEND_BURST, BURST_RAND_PUSH, data, bytesize, 0, node);
+}
+
+void VStreamBurstPushCheckRandom(uint8_t* data, const int bytesize, const uint32_t node)
+{
+    
+    VStreamBurstSendCommon(CHECK_BURST, BURST_RAND_PUSH, data, bytesize, 0, node);
+}
+

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -646,6 +646,47 @@ void VTransBurstCommon (const int op, const int param, const uint64_t addr, uint
 }
 
 // -------------------------------------------------------------------------
+// VTransGetCount
+//
+// Function to return various counts
+// -------------------------------------------------------------------------
+
+int VTransGetCount (const int op, const uint32_t node)
+{
+    rcv_buf_t  rbuf;
+    send_buf_t sbuf;
+
+    VInitSendBuf(sbuf);
+    
+    sbuf.op              = (addr_bus_trans_op_t)op;
+    
+    VExch(&sbuf, &rbuf, node);
+    
+    return rbuf.count;
+
+}
+
+// -------------------------------------------------------------------------
+// VTransTransactionWait
+//
+// Function wait on transactions
+// -------------------------------------------------------------------------
+
+void VTransTransactionWait (const int op, const uint32_t node)
+{
+    rcv_buf_t  rbuf;
+    send_buf_t sbuf;
+
+    VInitSendBuf(sbuf);
+    
+    sbuf.op              = (addr_bus_trans_op_t)op;
+    
+    VExch(&sbuf, &rbuf, node);
+    
+    return;
+}
+
+// -------------------------------------------------------------------------
 // VStreamUserCommon()
 //
 // Common 8-bit byte stream send/check transaction exchange function
@@ -944,6 +985,24 @@ bool VStreamUserBurstGetCommon (const int op, const int param, uint8_t* data, co
 
     // Return available status (sent back in unused interrupt field)
     return rbuf.interrupt;
+}
+
+// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
+
+int VStreamWaitGetCount (const int op, const bool txnrx, const uint32_t node)
+{
+    rcv_buf_t  rbuf;
+    send_buf_t sbuf;
+
+    VInitSendBuf(sbuf);
+    
+    sbuf.op                = (addr_bus_trans_op_t)op;
+    *((uint32_t*)sbuf.data) = txnrx ? 1 : 0;
+    
+    VExch(&sbuf, &rbuf, node);
+    
+    return txnrx ? rbuf.countsec : rbuf.count;
 }
 
 // -------------------------------------------------------------------------

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -356,13 +356,13 @@ void VWaitForSim(const uint32_t node)
 }
 
 // -------------------------------------------------------------------------
-// VTransCommon()
+// VTransUserCommon()
 //
 // Common 8-bit byte transaction exchange function (32-bit address)
 //
 // -------------------------------------------------------------------------
 
-uint8_t VTransCommon (const int op, const uint32_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
+uint8_t VTransUserCommon (const int op, const uint32_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -384,13 +384,13 @@ uint8_t VTransCommon (const int op, const uint32_t addr, const uint8_t data, int
 }
 
 // -------------------------------------------------------------------------
-// VTransCommon()
+// VTransUserCommon()
 //
 // Common 16-bit word transaction exchange function (32-bit address)
 //
 // -------------------------------------------------------------------------
 
-uint16_t VTransCommon (const int op, const uint32_t addr, const uint16_t data,  int* status, int const prot, const uint32_t node)
+uint16_t VTransUserCommon (const int op, const uint32_t addr, const uint16_t data,  int* status, int const prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -412,13 +412,13 @@ uint16_t VTransCommon (const int op, const uint32_t addr, const uint16_t data,  
 }
 
 // -------------------------------------------------------------------------
-// VTransCommon()
+// VTransUserCommon()
 //
 // Common 32-bit word transaction exchange function (32-bit address)
 //
 // -------------------------------------------------------------------------
 
-uint32_t VTransCommon (const int op, const uint32_t addr, const uint32_t data, int* status,  const int prot, const uint32_t node)
+uint32_t VTransUserCommon (const int op, const uint32_t addr, const uint32_t data, int* status,  const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -440,13 +440,13 @@ uint32_t VTransCommon (const int op, const uint32_t addr, const uint32_t data, i
 }
 
 // -------------------------------------------------------------------------
-// VTransCommon()
+// VTransUserCommon()
 //
 // Common 8-bit word transaction exchange function (64-bit address)
 //
 // -------------------------------------------------------------------------
 
-uint8_t VTransCommon (const int op, const uint64_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
+uint8_t VTransUserCommon (const int op, const uint64_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -468,13 +468,13 @@ uint8_t VTransCommon (const int op, const uint64_t addr, const uint8_t data, int
 }
 
 // -------------------------------------------------------------------------
-// VTransCommon()
+// VTransUserCommon()
 //
 // Common 16-bit word transaction exchange function (64-bit address)
 //
 // -------------------------------------------------------------------------
 
-uint16_t VTransCommon (const int op, const uint64_t addr, const uint16_t data, int* status, const int prot, const uint32_t node)
+uint16_t VTransUserCommon (const int op, const uint64_t addr, const uint16_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -496,13 +496,13 @@ uint16_t VTransCommon (const int op, const uint64_t addr, const uint16_t data, i
 }
 
 // -------------------------------------------------------------------------
-// VTransCommon()
+// VTransUserCommon()
 //
 // Common 32-bit word transaction exchange function (64-bit address)
 //
 // -------------------------------------------------------------------------
 
-uint32_t VTransCommon (const int op, const uint64_t addr, const uint32_t data, int* status, const int prot, const uint32_t node)
+uint32_t VTransUserCommon (const int op, const uint64_t addr, const uint32_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -524,13 +524,13 @@ uint32_t VTransCommon (const int op, const uint64_t addr, const uint32_t data, i
 }
 
 // -------------------------------------------------------------------------
-// VTransCommon()
+// VTransUserCommon()
 //
 // Common 64-bit word transaction exchange function (64-bit address)
 //
 // -------------------------------------------------------------------------
 
-uint64_t VTransCommon (const int op, const uint64_t addr, const uint64_t data, int* status, const int prot, const uint32_t node)
+uint64_t VTransUserCommon (const int op, const uint64_t addr, const uint64_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -646,13 +646,13 @@ void VTransBurstCommon (const int op, const int param, const uint64_t addr, uint
 }
 
 // -------------------------------------------------------------------------
-// VStreamCommon()
+// VStreamUserCommon()
 //
 // Common 8-bit byte stream send/check transaction exchange function
 //
 // -------------------------------------------------------------------------
 
-uint8_t VStreamCommon (const int op, const uint8_t data, const int param, const uint32_t node)
+uint8_t VStreamUserCommon (const int op, const uint8_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -671,13 +671,13 @@ uint8_t VStreamCommon (const int op, const uint8_t data, const int param, const 
 }
 
 // -------------------------------------------------------------------------
-// VStreamGetCommon()
+// VStreamUserGetCommon()
 //
 // Common 8-bit byte stream get transaction exchange
 //
 // -------------------------------------------------------------------------
 
-bool VStreamGetCommon (int op, uint8_t *rdata, int *status, const uint8_t wdata, const int param, const uint32_t node)
+bool VStreamUserGetCommon (int op, uint8_t *rdata, int *status, const uint8_t wdata, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -703,13 +703,13 @@ bool VStreamGetCommon (int op, uint8_t *rdata, int *status, const uint8_t wdata,
 }
 
 // -------------------------------------------------------------------------
-// VStreamCommon()
+// VStreamUserCommon()
 //
 // Common 16-bit word stream send/check transaction exchange function
 //
 // -------------------------------------------------------------------------
 
-uint16_t VStreamCommon (const int op, const uint16_t data, const int param, const uint32_t node)
+uint16_t VStreamUserCommon (const int op, const uint16_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -728,13 +728,13 @@ uint16_t VStreamCommon (const int op, const uint16_t data, const int param, cons
 }
 
 // -------------------------------------------------------------------------
-// VStreamGetCommon()
+// VStreamUserGetCommon()
 //
 // Common 16-bit word stream get transaction get exchange function
 //
 // -------------------------------------------------------------------------
 
-bool VStreamGetCommon (int op, uint16_t *rdata, int *status, const uint16_t wdata, const int param, const uint32_t node)
+bool VStreamUserGetCommon (int op, uint16_t *rdata, int *status, const uint16_t wdata, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -760,13 +760,13 @@ bool VStreamGetCommon (int op, uint16_t *rdata, int *status, const uint16_t wdat
 }
 
 // -------------------------------------------------------------------------
-// VStreamCommon()
+// VStreamUserCommon()
 //
 // Common 32-bit word stream send/check transaction exchange function
 //
 // -------------------------------------------------------------------------
 
-uint32_t VStreamCommon (const int op, const uint32_t data, const int param, const uint32_t node)
+uint32_t VStreamUserCommon (const int op, const uint32_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -786,13 +786,13 @@ uint32_t VStreamCommon (const int op, const uint32_t data, const int param, cons
 
 
 // -------------------------------------------------------------------------
-// VStreamGetCommon()
+// VStreamUserGetCommon()
 //
 // Common 32-bit word stream get transaction exchange function
 //
 // -------------------------------------------------------------------------
 
-bool VStreamGetCommon (int op, uint32_t *rdata, int *status, const uint32_t wdata, const int param, const uint32_t node)
+bool VStreamUserGetCommon (int op, uint32_t *rdata, int *status, const uint32_t wdata, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -818,13 +818,13 @@ bool VStreamGetCommon (int op, uint32_t *rdata, int *status, const uint32_t wdat
 }
 
 // -------------------------------------------------------------------------
-// VStreamCommon()
+// VStreamUserCommon()
 //
 // Common 64-bit word send/check transaction exchange function
 //
 // -------------------------------------------------------------------------
 
-uint64_t VStreamCommon (const int op, const uint64_t data, const int param, const uint32_t node)
+uint64_t VStreamUserCommon (const int op, const uint64_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -843,13 +843,13 @@ uint64_t VStreamCommon (const int op, const uint64_t data, const int param, cons
 }
 
 // -------------------------------------------------------------------------
-// VStreamGetCommon()
+// VStreamUserGetCommon()
 //
 // Common 64-bit word stream get transaction exchange function
 //
 // -------------------------------------------------------------------------
 
-bool VStreamGetCommon (int op, uint64_t *rdata, int *status, const uint64_t wdata, const int param,  const uint32_t node)
+bool VStreamUserGetCommon (int op, uint64_t *rdata, int *status, const uint64_t wdata, const int param,  const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -875,12 +875,12 @@ bool VStreamGetCommon (int op, uint64_t *rdata, int *status, const uint64_t wdat
 }
 
 // -------------------------------------------------------------------------
-// VStreamBurstSendCommon()
+// VStreamUserBurstSendCommon()
 //
 // Common function for Send/Check related stream transactions
 // -------------------------------------------------------------------------
 
-bool VStreamBurstSendCommon (const int op, const int burst_type, uint8_t* data, const int bytesize, const int param, const uint32_t node)
+bool VStreamUserBurstSendCommon (const int op, const int burst_type, uint8_t* data, const int bytesize, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -912,12 +912,12 @@ bool VStreamBurstSendCommon (const int op, const int burst_type, uint8_t* data, 
 }
 
 // -------------------------------------------------------------------------
-// VStreamBurstGetCommon()
+// VStreamUserBurstGetCommon()
 //
 // Common function for Get related stream transactions
 // -------------------------------------------------------------------------
 
-bool VStreamBurstGetCommon (const int op, const int param, uint8_t* data, const int bytesize, int* status, const uint32_t node)
+bool VStreamUserBurstGetCommon (const int op, const int param, uint8_t* data, const int bytesize, int* status, const uint32_t node)
 {
     rcv_buf_t    rbuf;
     send_buf_t   sbuf;

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -17,12 +17,14 @@
 //
 //  Revision History:
 //    Date      Version    Description
-//    10/2022   2023.01    Initial revision
+//    05/2023   2023.05    Adding asynchronous transaction support
+//    03/2023   2023.04    Adding basic stream support
+//    01/2023   2023.01    Initial revision
 //
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -331,23 +333,23 @@ void VWaitForSim(const uint32_t node)
 }
 
 // -------------------------------------------------------------------------
-// VTransWrite()
+// VTransCommon()
 //
-// Invokes an 8-bit write transaction exchange
+// Invokes an 8-bit transaction exchange
 //
 // -------------------------------------------------------------------------
 
-uint8_t VTransWrite (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
+static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans32_wr_byte;
+    sbuf.type            = trans32_byte;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = WRITE_OP;
+    sbuf.op              = op;
 
     *((uint8_t*)sbuf.data) = data & 0xffU;
 
@@ -357,46 +359,22 @@ uint8_t VTransWrite (const uint32_t addr, const uint8_t data, const int prot, co
 }
 
 // -------------------------------------------------------------------------
-// VTransRead()
+// VTransCommon()
 //
-// Invokes an 8-bit read transaction exchange
+// Invokes an 16-bit transaction exchange
 //
 // -------------------------------------------------------------------------
-
-void VTransRead (const uint32_t addr, uint8_t *rdata, const int prot, const uint32_t node)
+static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint16_t data, int const prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans32_rd_byte;
+    sbuf.type            = trans32_hword;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = READ_OP;
-
-    VExch(&sbuf, &rbuf, node);
-
-    *rdata = rbuf.data_in & 0xffU;
-}
-
-// -------------------------------------------------------------------------
-// VTransWrite()
-//
-// Invokes an 16-bit write transaction exchange
-//
-// -------------------------------------------------------------------------
-uint16_t VTransWrite (const uint32_t addr, const uint16_t data, int const prot, const uint32_t node)
-{
-    rcv_buf_t  rbuf;
-    send_buf_t sbuf;
-
-    VInitSendBuf(sbuf);
-
-    sbuf.type            = trans32_wr_hword;
-    sbuf.addr            = addr;
-    sbuf.prot            = prot;
-    sbuf.op              = WRITE_OP;
+    sbuf.op              = op;
 
     *((uint16_t*)sbuf.data) = data & 0xffffU;
 
@@ -406,47 +384,23 @@ uint16_t VTransWrite (const uint32_t addr, const uint16_t data, int const prot, 
 }
 
 // -------------------------------------------------------------------------
-// VTransRead()
+// VTransCommon()
 //
-// Invokes an 16-bit write transaction exchange
+// Invokes an 32-bit transaction exchange
 //
 // -------------------------------------------------------------------------
 
-void VTransRead (const uint32_t addr, uint16_t *rdata, const int prot, const uint32_t node)
+static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans32_rd_hword;
+    sbuf.type            = trans32_word;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = READ_OP;
-
-    VExch(&sbuf, &rbuf, node);
-
-    *rdata = rbuf.data_in & 0xffffU;
-}
-
-// -------------------------------------------------------------------------
-// VTransWrite()
-//
-// Invokes an 32-bit write transaction exchange
-//
-// -------------------------------------------------------------------------
-
-uint32_t VTransWrite (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    rcv_buf_t  rbuf;
-    send_buf_t sbuf;
-
-    VInitSendBuf(sbuf);
-
-    sbuf.type            = trans32_wr_word;
-    sbuf.addr            = addr;
-    sbuf.prot            = prot;
-    sbuf.op              = WRITE_OP;
+    sbuf.op              = op;
 
     *((uint32_t*)sbuf.data) = data;
 
@@ -456,47 +410,23 @@ uint32_t VTransWrite (const uint32_t addr, const uint32_t data, const int prot, 
 }
 
 // -------------------------------------------------------------------------
-// VTransRead()
+// VTransCommon()
 //
-// Invokes an 32-bit write transaction exchange
+// Invokes an 8-bit transaction exchange (64-bit address)
 //
 // -------------------------------------------------------------------------
 
-void VTransRead (const uint32_t addr, uint32_t *rdata, const int prot, const uint32_t node)
+static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans32_rd_word;
+    sbuf.type            = trans64_byte;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = READ_OP;
-
-    VExch(&sbuf, &rbuf, node);
-
-    *rdata = rbuf.data_in;
-}
-
-// -------------------------------------------------------------------------
-// VTransWrite()
-//
-// Invokes an 8-bit write transaction exchange (64-bit address)
-//
-// -------------------------------------------------------------------------
-
-uint8_t VTransWrite (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    rcv_buf_t  rbuf;
-    send_buf_t sbuf;
-
-    VInitSendBuf(sbuf);
-
-    sbuf.type            = trans64_wr_byte;
-    sbuf.addr            = addr;
-    sbuf.prot            = prot;
-    sbuf.op              = WRITE_OP;
+    sbuf.op              = op;
 
     *((uint8_t*)sbuf.data) = data & 0xffU;
 
@@ -506,47 +436,23 @@ uint8_t VTransWrite (const uint64_t addr, const uint8_t data, const int prot, co
 }
 
 // -------------------------------------------------------------------------
-// VTransRead()
+// VTransCommon()
 //
-// Invokes an 8-bit read transaction exchange (64-bit address)
+// Invokes an 16-bit transaction exchange (64-bit address)
 //
 // -------------------------------------------------------------------------
 
-void VTransRead (const uint64_t addr, uint8_t *rdata, const int prot, const uint32_t node)
+static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans64_rd_byte;
+    sbuf.type            = trans64_hword;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = READ_OP;
-
-    VExch(&sbuf, &rbuf, node);
-
-    *rdata = rbuf.data_in & 0xffU;
-}
-
-// -------------------------------------------------------------------------
-// VTransWrite()
-//
-// Invokes an 16-bit write transaction exchange (64-bit address)
-//
-// -------------------------------------------------------------------------
-
-uint16_t VTransWrite (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    rcv_buf_t  rbuf;
-    send_buf_t sbuf;
-
-    VInitSendBuf(sbuf);
-
-    sbuf.type            = trans64_wr_hword;
-    sbuf.addr            = addr;
-    sbuf.prot            = prot;
-    sbuf.op              = WRITE_OP;
+    sbuf.op              = op;
 
     *((uint16_t*)sbuf.data) = data & 0xffffU;
 
@@ -556,47 +462,23 @@ uint16_t VTransWrite (const uint64_t addr, const uint16_t data, const int prot, 
 }
 
 // -------------------------------------------------------------------------
-// VTransRead()
+// VTransCommon()
 //
-// Invokes an 16-bit read transaction exchange (64-bit address)
+// Invokes an 32-bit transaction exchange (64-bit address)
 //
 // -------------------------------------------------------------------------
 
-void VTransRead (const uint64_t addr, uint16_t *rdata, const int prot, const uint32_t node)
+static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans64_rd_hword;
+    sbuf.type            = trans64_word;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = READ_OP;
-
-    VExch(&sbuf, &rbuf, node);
-
-    *rdata = rbuf.data_in & 0xffffU;
-}
-
-// -------------------------------------------------------------------------
-// VTransWrite()
-//
-// Invokes an 32-bit write transaction exchange (64-bit address)
-//
-// -------------------------------------------------------------------------
-
-uint32_t VTransWrite (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    rcv_buf_t  rbuf;
-    send_buf_t sbuf;
-
-    VInitSendBuf(sbuf);
-
-    sbuf.type            = trans64_wr_word;
-    sbuf.addr            = addr;
-    sbuf.prot            = prot;
-    sbuf.op              = WRITE_OP;
+    sbuf.op              = op;
 
     *((uint32_t*)sbuf.data) = data;
 
@@ -606,47 +488,23 @@ uint32_t VTransWrite (const uint64_t addr, const uint32_t data, const int prot, 
 }
 
 // -------------------------------------------------------------------------
-// VTransRead()
+// VTransCommon()
 //
-// Invokes an 32-bit read transaction exchange (64-bit address)
+// Invokes an 64-bit transaction exchange (64-bit address)
 //
 // -------------------------------------------------------------------------
 
-void VTransRead (const uint64_t addr, uint32_t *rdata, const int prot, const uint32_t node)
+static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans64_rd_word;
+    sbuf.type            = trans64_dword;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = READ_OP;
-
-    VExch(&sbuf, &rbuf, node);
-
-    *rdata = rbuf.data_in;
-}
-
-// -------------------------------------------------------------------------
-// VTransWrite()
-//
-// Invokes an 64-bit write transaction exchange (64-bit address)
-//
-// -------------------------------------------------------------------------
-
-uint64_t VTransWrite (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
-{
-    rcv_buf_t  rbuf;
-    send_buf_t sbuf;
-
-    VInitSendBuf(sbuf);
-
-    sbuf.type            = trans64_wr_dword;
-    sbuf.addr            = addr;
-    sbuf.prot            = prot;
-    sbuf.op              = WRITE_OP;
+    sbuf.op              = op;
 
     *((uint64_t*)sbuf.data) = data;
 
@@ -656,46 +514,22 @@ uint64_t VTransWrite (const uint64_t addr, const uint64_t data, const int prot, 
 }
 
 // -------------------------------------------------------------------------
-// VTransRead()
-//
-// Invokes an 64-bit read transaction exchange (64-bit address)
-//
-// -------------------------------------------------------------------------
-
-void VTransRead (const uint64_t addr, uint64_t *rdata, const int prot, const uint32_t node)
-{
-    rcv_buf_t    rbuf;
-    send_buf_t   sbuf;
-
-    VInitSendBuf(sbuf);
-
-    sbuf.type            = trans64_rd_dword;
-    sbuf.addr            = addr;
-    sbuf.prot            = prot;
-    sbuf.op              = READ_OP;
-
-    VExch(&sbuf, &rbuf, node);
-
-    *rdata = (uint64_t)rbuf.data_in | ((uint64_t)rbuf.data_in_hi << 32);
-}
-
-// -------------------------------------------------------------------------
-// VTransBurstWrite()
+// VTransBurstWriteCommon()
 //
 // Invokes a write burst transaction exchange (32-bit address)
 // -------------------------------------------------------------------------
 
-void VTransBurstWrite (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans32_wr_burst;
+    sbuf.type            = trans32_burst;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = WRITE_BURST;
+    sbuf.op              = op;
     sbuf.num_burst_bytes = bytesize % DATABUF_SIZE;
 
     for (int idx = 0; idx < sbuf.num_burst_bytes; idx++)
@@ -709,22 +543,22 @@ void VTransBurstWrite (const uint32_t addr, uint8_t* data, const int bytesize, c
 }
 
 // -------------------------------------------------------------------------
-// VTransBurstWrite()
+// VTransBurstWriteCommon()
 //
 // Invokes a write burst transaction exchange (64-bit address)
 // -------------------------------------------------------------------------
 
-void VTransBurstWrite (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans64_wr_burst;
+    sbuf.type            = trans64_burst;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = WRITE_BURST;
+    sbuf.op              = op;
     sbuf.num_burst_bytes = bytesize % DATABUF_SIZE;
 
     for (int idx = 0; idx < sbuf.num_burst_bytes; idx++)
@@ -750,7 +584,7 @@ void VTransBurstRead  (const uint32_t addr, uint8_t* data, const int bytesize, c
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans32_rd_burst;
+    sbuf.type            = trans32_burst;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
     sbuf.op              = READ_BURST;
@@ -779,7 +613,7 @@ void VTransBurstRead  (const uint64_t addr, uint8_t* data, const int bytesize, c
 
     VInitSendBuf(sbuf);
 
-    sbuf.type            = trans64_rd_burst;
+    sbuf.type            = trans64_burst;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
     sbuf.op              = READ_BURST;
@@ -796,13 +630,13 @@ void VTransBurstRead  (const uint64_t addr, uint8_t* data, const int bytesize, c
 }
 
 // -------------------------------------------------------------------------
-// VStreamSend()
+// VStreamSendCommon()
 //
 // Invokes an 8-bit send transaction exchange
 //
 // -------------------------------------------------------------------------
 
-uint8_t VStreamSend (const uint8_t data, const int param, const uint32_t node)
+uint8_t VStreamSendCommon (const stream_operation_t op, const uint8_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -810,7 +644,7 @@ uint8_t VStreamSend (const uint8_t data, const int param, const uint32_t node)
     VInitSendBuf(sbuf);
 
     sbuf.type            = stream_snd_byte;
-    sbuf.op              = (addr_bus_trans_op_t)SEND;
+    sbuf.op              = (addr_bus_trans_op_t)op;
     sbuf.param           = param;
 
     *((uint8_t*)sbuf.data) = data & 0xffU;
@@ -844,13 +678,13 @@ void VStreamGet (uint8_t *rdata, int *status, const uint32_t node)
 }
 
 // -------------------------------------------------------------------------
-// VStreamSend()
+// VStreamSendCommon()
 //
 // Invokes an 16-bit send transaction exchange
 //
 // -------------------------------------------------------------------------
 
-uint8_t VStreamSend (const uint16_t data, const int param, const uint32_t node)
+uint16_t VStreamSendCommon (const stream_operation_t op, const uint16_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -858,7 +692,7 @@ uint8_t VStreamSend (const uint16_t data, const int param, const uint32_t node)
     VInitSendBuf(sbuf);
 
     sbuf.type            = stream_snd_hword;
-    sbuf.op              = (addr_bus_trans_op_t)SEND;
+    sbuf.op              = (addr_bus_trans_op_t)op;
     sbuf.param           = param;
 
     *((uint16_t*)sbuf.data) = data & 0xffffU;
@@ -892,13 +726,13 @@ void VStreamGet (uint16_t *rdata, int *status, const uint32_t node)
 }
 
 // -------------------------------------------------------------------------
-// VStreamSend()
+// VStreamSendCommon()
 //
 // Invokes an 32-bit send transaction exchange
 //
 // -------------------------------------------------------------------------
 
-uint8_t VStreamSend (const uint32_t data, const int param, const uint32_t node)
+uint32_t VStreamSendCommon (const stream_operation_t op, const uint32_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -906,7 +740,7 @@ uint8_t VStreamSend (const uint32_t data, const int param, const uint32_t node)
     VInitSendBuf(sbuf);
 
     sbuf.type            = stream_snd_word;
-    sbuf.op              = (addr_bus_trans_op_t)SEND;
+    sbuf.op              = (addr_bus_trans_op_t)op;
     sbuf.param           = param;
 
     *((uint32_t*)sbuf.data) = data & 0xffffffffU;
@@ -941,13 +775,13 @@ void VStreamGet (uint32_t *rdata, int *status, const uint32_t node)
 }
 
 // -------------------------------------------------------------------------
-// VStreamSend()
+// VStreamSendCommon()
 //
 // Invokes an 64-bit send transaction exchange
 //
 // -------------------------------------------------------------------------
 
-uint8_t VStreamSend (const uint64_t data, const int param, const uint32_t node)
+uint64_t VStreamSendCommon (const stream_operation_t op, const uint64_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -955,7 +789,7 @@ uint8_t VStreamSend (const uint64_t data, const int param, const uint32_t node)
     VInitSendBuf(sbuf);
 
     sbuf.type            = stream_snd_dword;
-    sbuf.op              = (addr_bus_trans_op_t)SEND;
+    sbuf.op              = (addr_bus_trans_op_t)op;
     sbuf.param           = param;
 
     *((uint64_t*)sbuf.data) = data;
@@ -989,12 +823,12 @@ void VStreamGet (uint64_t *rdata, int *status, const uint32_t node)
 }
 
 // -------------------------------------------------------------------------
-// VStreamBurstSend()
+// VStreamBurstSendCommon()
 //
 // Invokes a send burst transaction exchange )
 // -------------------------------------------------------------------------
 
-void VStreamBurstSend (uint8_t* data, const int bytesize, const uint32_t node)
+void VStreamBurstSendCommon (const stream_operation_t op, uint8_t* data, const int bytesize, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -1002,7 +836,7 @@ void VStreamBurstSend (uint8_t* data, const int bytesize, const uint32_t node)
     VInitSendBuf(sbuf);
 
     sbuf.type            = stream_snd_burst;
-    sbuf.op              = (addr_bus_trans_op_t)SEND_BURST;
+    sbuf.op              = (addr_bus_trans_op_t)op;
     sbuf.num_burst_bytes = bytesize % DATABUF_SIZE;
 
     for (int idx = 0; idx < sbuf.num_burst_bytes; idx++)
@@ -1119,4 +953,316 @@ void VSetTestName (const char* data, const int bytesize, const uint32_t node)
 
     return;
 }
+
+// -------------------------------------------------------------------------
+// Wrapper functions for sync and async operations for the various
+// overloaded versions of the files, calling common routines with different
+// operation codes.
+// -------------------------------------------------------------------------
+
+void VTransRead (const uint32_t addr, uint8_t *rdata, const int prot, const uint32_t node)
+{
+    *rdata = VTransCommon(READ_OP, addr, (uint8_t)0, prot, node);
+}
+
+void VTransRead (const uint32_t addr, uint16_t *rdata, const int prot, const uint32_t node)
+{
+    *rdata = VTransCommon(READ_OP, addr, (uint16_t)0, prot, node);
+}
+
+void VTransRead (const uint32_t addr, uint32_t *rdata, const int prot, const uint32_t node)
+{
+    *rdata = VTransCommon(READ_OP, addr, (uint32_t)0, prot, node);
+}
+
+void VTransRead (const uint64_t addr, uint8_t *rdata, const int prot, const uint32_t node)
+{
+    *rdata = VTransCommon(READ_OP, addr, (uint8_t)0, prot, node);
+}
+
+void VTransRead (const uint64_t addr, uint16_t *rdata, const int prot, const uint32_t node)
+{
+    *rdata = VTransCommon(READ_OP, addr, (uint16_t)0, prot, node);
+}
+
+void VTransRead (const uint64_t addr, uint32_t *rdata, const int prot, const uint32_t node)
+{
+    *rdata = VTransCommon(READ_OP, addr, (uint32_t)0, prot, node);
+}
+
+void VTransRead (const uint64_t addr, uint64_t *rdata, const int prot, const uint32_t node)
+{
+    *rdata = VTransCommon(READ_OP, addr, (uint64_t)0, prot, node);
+}
+
+uint8_t VTransWrite (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_OP, addr, data, prot, node);
+}
+
+uint8_t VTransWriteAsync (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+}
+
+uint16_t VTransWrite (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_OP, addr, data, prot, node);
+}
+
+uint16_t VTransWriteAsync (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+}
+
+uint32_t VTransWrite (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_OP, addr, data, prot, node);
+}
+
+uint32_t VTransWriteAsync (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+}
+
+uint8_t VTransWrite (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_OP, addr, data, prot, node);
+}
+
+uint8_t VTransWriteAsync (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+}
+
+uint16_t VTransWrite (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_OP, addr, data, prot, node);
+}
+
+uint16_t VTransWriteAsync (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+}
+
+uint32_t VTransWrite (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_OP, addr, data, prot, node);
+}
+
+uint32_t VTransWriteAsync (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+}
+
+uint64_t VTransWrite (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_OP, addr, data, prot, node);
+}
+
+uint64_t VTransWriteAsync (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+}
+
+uint8_t VTransWriteAndRead (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint8_t VTransWriteAndReadAsync (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint16_t VTransWriteAndRead (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint16_t VTransWriteAndReadAsync (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint32_t VTransWriteAndRead (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint32_t VTransWriteAndReadAsync (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint8_t VTransWriteAndRead (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint8_t VTransWriteAndReadAsync (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint16_t VTransWriteAndRead (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint16_t VTransWriteAndReadAsync (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint32_t VTransWriteAndRead (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint32_t VTransWriteAndReadAsync (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint64_t VTransWriteAndRead (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+}
+
+uint64_t VTransWriteAndReadAsync (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
+{
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+}
+
+void VTransWriteAddressAsync (const uint32_t addr, const uint32_t node)
+{
+    VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, 0, node);
+}
+
+void VTransWriteAddressAsync (const uint64_t addr, const uint32_t node)
+{
+    VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, 0, node);
+}
+
+void VTransWriteDataAsync (const uint8_t  data, const uint32_t bytelane, const uint32_t node)
+{
+    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, 0, node);
+}
+
+void VTransWriteDataAsync (const uint16_t data, const uint32_t bytelane, const uint32_t node)
+{
+    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, 0, node);
+}
+
+void VTransWriteDataAsync (const uint32_t data, const uint32_t bytelane, const uint32_t node)
+{
+    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, 0, node);
+}
+
+void VTransWriteDataAsync (const uint64_t data, const uint64_t bytelane, const uint32_t node)
+{
+    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, 0, node);
+}
+
+void VTransReadAddressAsync  (const uint32_t addr, const uint32_t node)
+{
+    VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, 0, node);
+}
+
+void VTransReadAddressAsync  (const uint64_t addr, const uint32_t node)
+{
+    VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, 0, node);
+}
+
+void VTransReadData (uint8_t  *data, const uint32_t node)
+{
+    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, 0, node);
+}
+
+void VTransReadData (uint16_t *data, const uint32_t node)
+{
+    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint16_t)0, 0, node);
+}
+
+void VTransReadData (uint32_t *data, const uint32_t node)
+{
+    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint32_t)0, 0, node);
+}
+
+void VTransReadData (uint64_t  *data, const uint32_t node)
+{
+    *data = VTransCommon(READ_DATA, (uint64_t)0, (uint64_t)0, 0, node);
+}
+
+void VTransBurstWrite (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(WRITE_BURST, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWrite (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(WRITE_BURST, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(ASYNC_WRITE_BURST, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(ASYNC_WRITE_BURST, addr, data, bytesize, prot, node);
+}
+
+uint8_t VStreamSend (const uint8_t data, const int param, const uint32_t node)
+{
+    return VStreamSendCommon(SEND, data, param, node);
+}
+
+uint16_t VStreamSend (const uint16_t data, const int param, const uint32_t node)
+{
+    return VStreamSendCommon(SEND, data, param, node);
+}
+
+uint32_t VStreamSend (const uint32_t data, const int param, const uint32_t node)
+{
+    return VStreamSendCommon(SEND, data, param, node);
+}
+
+uint64_t VStreamSend (const uint64_t data, const int param, const uint32_t node)
+{
+    return VStreamSendCommon(SEND, data, param, node);
+}
+
+uint8_t VStreamSendAsync (const uint8_t data, const int param, const uint32_t node)
+{
+    return VStreamSendCommon(SEND_ASYNC, data, param, node);
+}
+
+uint16_t VStreamSendAsync (const uint16_t data, const int param, const uint32_t node)
+{
+    return VStreamSendCommon(SEND_ASYNC, data, param, node);
+}
+
+uint32_t VStreamSendAsync (const uint32_t data, const int param, const uint32_t node)
+{
+    return VStreamSendCommon(SEND_ASYNC, data, param, node);
+}
+
+uint64_t VStreamSendAsync (const uint64_t data, const int param, const uint32_t node)
+{
+    return VStreamSendCommon(SEND_ASYNC, data, param, node);
+}
+
+void VStreamBurstSend (uint8_t* data, const int bytesize, const uint32_t node)
+{
+    VStreamBurstSendCommon(SEND_BURST, data, bytesize, node);
+}
+
+void VStreamBurstSendAsync (uint8_t* data, const int bytesize, const uint32_t node)
+{
+    VStreamBurstSendCommon(SEND_BURST_ASYNC, data, bytesize, node);
+}
+
 

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -362,7 +362,7 @@ void VWaitForSim(const uint32_t node)
 //
 // -------------------------------------------------------------------------
 
-static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
+uint8_t VTransCommon (const int op, const uint32_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -372,7 +372,7 @@ static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, 
     sbuf.type            = trans32_byte;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
 
     *((uint8_t*)sbuf.data) = data & 0xffU;
 
@@ -389,7 +389,8 @@ static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, 
 // Common 16-bit word transaction exchange function (32-bit address)
 //
 // -------------------------------------------------------------------------
-static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint16_t data,  int* status, int const prot, const uint32_t node)
+
+uint16_t VTransCommon (const int op, const uint32_t addr, const uint16_t data,  int* status, int const prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -399,7 +400,7 @@ static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr,
     sbuf.type            = trans32_hword;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
 
     *((uint16_t*)sbuf.data) = data & 0xffffU;
 
@@ -417,7 +418,7 @@ static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr,
 //
 // -------------------------------------------------------------------------
 
-static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint32_t data, int* status,  const int prot, const uint32_t node)
+uint32_t VTransCommon (const int op, const uint32_t addr, const uint32_t data, int* status,  const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -427,7 +428,7 @@ static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr,
     sbuf.type            = trans32_word;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
 
     *((uint32_t*)sbuf.data) = data;
 
@@ -445,7 +446,7 @@ static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr,
 //
 // -------------------------------------------------------------------------
 
-static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
+uint8_t VTransCommon (const int op, const uint64_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -455,7 +456,7 @@ static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, 
     sbuf.type            = trans64_byte;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
 
     *((uint8_t*)sbuf.data) = data & 0xffU;
 
@@ -473,7 +474,7 @@ static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, 
 //
 // -------------------------------------------------------------------------
 
-static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint16_t data, int* status, const int prot, const uint32_t node)
+uint16_t VTransCommon (const int op, const uint64_t addr, const uint16_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -483,7 +484,7 @@ static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
     sbuf.type            = trans64_hword;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
 
     *((uint16_t*)sbuf.data) = data & 0xffffU;
 
@@ -501,7 +502,7 @@ static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 //
 // -------------------------------------------------------------------------
 
-static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint32_t data, int* status, const int prot, const uint32_t node)
+uint32_t VTransCommon (const int op, const uint64_t addr, const uint32_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -511,7 +512,7 @@ static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
     sbuf.type            = trans64_word;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
 
     *((uint32_t*)sbuf.data) = data;
 
@@ -529,7 +530,7 @@ static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 //
 // -------------------------------------------------------------------------
 
-static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint64_t data, int* status, const int prot, const uint32_t node)
+uint64_t VTransCommon (const int op, const uint64_t addr, const uint64_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -539,7 +540,7 @@ static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
     sbuf.type            = trans64_dword;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
 
     *((uint64_t*)sbuf.data) = data;
 
@@ -557,7 +558,7 @@ static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 //
 // -------------------------------------------------------------------------
 
-static void VTransBurstCommon (const addr_bus_trans_op_t op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+void VTransBurstCommon (const int op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -567,7 +568,7 @@ static void VTransBurstCommon (const addr_bus_trans_op_t op, const int param, co
     sbuf.type            = trans32_burst;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
     sbuf.param           = param;
     sbuf.num_burst_bytes = bytesize % DATABUF_SIZE;
 
@@ -604,7 +605,7 @@ static void VTransBurstCommon (const addr_bus_trans_op_t op, const int param, co
 //
 // -------------------------------------------------------------------------
 
-static void VTransBurstCommon (const addr_bus_trans_op_t op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+void VTransBurstCommon (const int op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -614,7 +615,7 @@ static void VTransBurstCommon (const addr_bus_trans_op_t op, const int param, co
     sbuf.type            = trans64_burst;
     sbuf.addr            = addr;
     sbuf.prot            = prot;
-    sbuf.op              = op;
+    sbuf.op              = (addr_bus_trans_op_t)op;
     sbuf.param           = param;
     sbuf.num_burst_bytes = bytesize % DATABUF_SIZE;
 
@@ -651,7 +652,7 @@ static void VTransBurstCommon (const addr_bus_trans_op_t op, const int param, co
 //
 // -------------------------------------------------------------------------
 
-static uint8_t VStreamCommon (const stream_operation_t op, const uint8_t data, const int param, const uint32_t node)
+uint8_t VStreamCommon (const int op, const uint8_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -676,7 +677,7 @@ static uint8_t VStreamCommon (const stream_operation_t op, const uint8_t data, c
 //
 // -------------------------------------------------------------------------
 
-static bool VStreamGetCommon (int op, uint8_t *rdata, int *status, const uint8_t wdata, const int param, const uint32_t node)
+bool VStreamGetCommon (int op, uint8_t *rdata, int *status, const uint8_t wdata, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -708,7 +709,7 @@ static bool VStreamGetCommon (int op, uint8_t *rdata, int *status, const uint8_t
 //
 // -------------------------------------------------------------------------
 
-static uint16_t VStreamCommon (const stream_operation_t op, const uint16_t data, const int param, const uint32_t node)
+uint16_t VStreamCommon (const int op, const uint16_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -733,7 +734,7 @@ static uint16_t VStreamCommon (const stream_operation_t op, const uint16_t data,
 //
 // -------------------------------------------------------------------------
 
-static bool VStreamGetCommon (int op, uint16_t *rdata, int *status, const uint16_t wdata, const int param, const uint32_t node)
+bool VStreamGetCommon (int op, uint16_t *rdata, int *status, const uint16_t wdata, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -765,7 +766,7 @@ static bool VStreamGetCommon (int op, uint16_t *rdata, int *status, const uint16
 //
 // -------------------------------------------------------------------------
 
-static uint32_t VStreamCommon (const stream_operation_t op, const uint32_t data, const int param, const uint32_t node)
+uint32_t VStreamCommon (const int op, const uint32_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -791,7 +792,7 @@ static uint32_t VStreamCommon (const stream_operation_t op, const uint32_t data,
 //
 // -------------------------------------------------------------------------
 
-static bool VStreamGetCommon (int op, uint32_t *rdata, int *status, const uint32_t wdata, const int param, const uint32_t node)
+bool VStreamGetCommon (int op, uint32_t *rdata, int *status, const uint32_t wdata, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -823,7 +824,7 @@ static bool VStreamGetCommon (int op, uint32_t *rdata, int *status, const uint32
 //
 // -------------------------------------------------------------------------
 
-static uint64_t VStreamCommon (const stream_operation_t op, const uint64_t data, const int param, const uint32_t node)
+uint64_t VStreamCommon (const int op, const uint64_t data, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -848,7 +849,7 @@ static uint64_t VStreamCommon (const stream_operation_t op, const uint64_t data,
 //
 // -------------------------------------------------------------------------
 
-static bool VStreamGetCommon (int op, uint64_t *rdata, int *status, const uint64_t wdata, const int param,  const uint32_t node)
+bool VStreamGetCommon (int op, uint64_t *rdata, int *status, const uint64_t wdata, const int param,  const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -879,7 +880,7 @@ static bool VStreamGetCommon (int op, uint64_t *rdata, int *status, const uint64
 // Common function for Send/Check related stream transactions
 // -------------------------------------------------------------------------
 
-static bool VStreamBurstSendCommon (const stream_operation_t op, const int burst_type, uint8_t* data, const int bytesize, const int param, const uint32_t node)
+bool VStreamBurstSendCommon (const int op, const int burst_type, uint8_t* data, const int bytesize, const int param, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -916,7 +917,7 @@ static bool VStreamBurstSendCommon (const stream_operation_t op, const int burst
 // Common function for Get related stream transactions
 // -------------------------------------------------------------------------
 
-static bool VStreamBurstGetCommon (const int op, const int param, uint8_t* data, const int bytesize, int* status, const uint32_t node)
+bool VStreamBurstGetCommon (const int op, const int param, uint8_t* data, const int bytesize, int* status, const uint32_t node)
 {
     rcv_buf_t    rbuf;
     send_buf_t   sbuf;
@@ -1023,793 +1024,5 @@ void VSetTestName (const char* data, const int bytesize, const uint32_t node)
     return;
 }
 
-// -------------------------------------------------------------------------
-// Wrapper functions for the transaction operations for the various
-// overloaded versions, calling common routines with different operation
-// codes.
-// -------------------------------------------------------------------------
 
-void VTransRead (const uint32_t addr, uint8_t *rdata, const int prot, const uint32_t node)
-{
-    *rdata = VTransCommon(READ_OP, addr, (uint8_t)0, &unusedstatus, prot, node);
-}
-
-void VTransRead (const uint32_t addr, uint16_t *rdata, const int prot, const uint32_t node)
-{
-    *rdata = VTransCommon(READ_OP, addr, (uint16_t)0, &unusedstatus, prot, node);
-}
-
-void VTransRead (const uint32_t addr, uint32_t *rdata, const int prot, const uint32_t node)
-{
-    *rdata = VTransCommon(READ_OP, addr, (uint32_t)0, &unusedstatus, prot, node);
-}
-
-void VTransRead (const uint64_t addr, uint8_t *rdata, const int prot, const uint32_t node)
-{
-    *rdata = VTransCommon(READ_OP, addr, (uint8_t)0, &unusedstatus, prot, node);
-}
-
-void VTransRead (const uint64_t addr, uint16_t *rdata, const int prot, const uint32_t node)
-{
-    *rdata = VTransCommon(READ_OP, addr, (uint16_t)0, &unusedstatus, prot, node);
-}
-
-void VTransRead (const uint64_t addr, uint32_t *rdata, const int prot, const uint32_t node)
-{
-    *rdata = VTransCommon(READ_OP, addr, (uint32_t)0, &unusedstatus, prot, node);
-}
-
-void VTransRead (const uint64_t addr, uint64_t *rdata, const int prot, const uint32_t node)
-{
-    *rdata = VTransCommon(READ_OP, addr, (uint64_t)0, &unusedstatus, prot, node);
-}
-
-uint8_t VTransWrite (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
-}
-
-uint8_t VTransWriteAsync (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
-}
-
-uint16_t VTransWrite (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
-}
-
-uint16_t VTransWriteAsync (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
-}
-
-uint32_t VTransWrite (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
-}
-
-uint32_t VTransWriteAsync (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
-}
-
-uint8_t VTransWrite (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
-}
-
-uint8_t VTransWriteAsync (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
-}
-
-uint16_t VTransWrite (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
-}
-
-uint16_t VTransWriteAsync (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
-}
-
-uint32_t VTransWrite (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
-}
-
-uint32_t VTransWriteAsync (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-     return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
-}
-
-uint64_t VTransWrite (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
-}
-
-uint64_t VTransWriteAsync (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
-}
-
-uint8_t VTransWriteAndRead (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint8_t VTransWriteAndReadAsync (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint16_t VTransWriteAndRead (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint16_t VTransWriteAndReadAsync (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint32_t VTransWriteAndRead (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint32_t VTransWriteAndReadAsync (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint8_t VTransWriteAndRead (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint8_t VTransWriteAndReadAsync (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint16_t VTransWriteAndRead (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint16_t VTransWriteAndReadAsync (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint32_t VTransWriteAndRead (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint32_t VTransWriteAndReadAsync (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint64_t VTransWriteAndRead (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-uint64_t VTransWriteAndReadAsync (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
-{
-    return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
-}
-
-void VTransWriteAddressAsync (const uint32_t addr, const uint32_t node)
-{
-    VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &unusedstatus, 0, node);
-}
-
-void VTransWriteAddressAsync (const uint64_t addr, const uint32_t node)
-{
-    VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &unusedstatus, 0, node);
-}
-
-void VTransWriteDataAsync (const uint8_t  data, const uint32_t bytelane, const uint32_t node)
-{
-    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &unusedstatus, 0, node);
-}
-
-void VTransWriteDataAsync (const uint16_t data, const uint32_t bytelane, const uint32_t node)
-{
-    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &unusedstatus, 0, node);
-}
-
-void VTransWriteDataAsync (const uint32_t data, const uint32_t bytelane, const uint32_t node)
-{
-    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &unusedstatus, 0, node);
-}
-
-void VTransWriteDataAsync (const uint64_t data, const uint64_t bytelane, const uint32_t node)
-{
-    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &unusedstatus, 0, node);
-}
-
-void VTransReadAddressAsync  (const uint32_t addr, const uint32_t node)
-{
-    VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &unusedstatus, 0, node);
-}
-
-void VTransReadAddressAsync  (const uint64_t addr, const uint32_t node)
-{
-    VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &unusedstatus, 0, node);
-}
-
-void VTransReadData (uint8_t  *data, const uint32_t node)
-{
-    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &unusedstatus, 0, node);
-}
-
-void VTransReadData (uint16_t *data, const uint32_t node)
-{
-    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint16_t)0, &unusedstatus, 0, node);
-}
-
-void VTransReadData (uint32_t *data, const uint32_t node)
-{
-    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint32_t)0, &unusedstatus, 0, node);
-}
-
-void VTransReadData (uint64_t  *data, const uint32_t node)
-{
-    *data = VTransCommon(READ_DATA, (uint64_t)0, (uint64_t)0, &unusedstatus, 0, node);
-}
-
-bool VTransTryReadData (uint8_t *data, const uint32_t node)
-{
-    int status;
-
-    *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);
-
-    return status;
-}
-
-bool VTransTryReadData (uint16_t *data, const uint32_t node)
-{
-    int status;
-
-    *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint16_t)0, &status, 0, node);
-
-    return status;
-}
-
-bool VTransTryReadData (uint32_t *data, const uint32_t node)
-{
-    int status;
-
-    *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint32_t)0, &status, 0, node);
-
-    return status;
-}
-
-bool VTransTryReadData (uint64_t *data, const uint32_t node)
-{
-    int status;
-
-    *data = VTransCommon(ASYNC_READ_DATA, (uint64_t)0, (uint64_t)0, &status, 0, node);
-
-    return status;
-}
-
-void  VTransReadCheck (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
-}
-
-void  VTransReadCheck (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
-}
-
-void  VTransReadCheck (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
-}
-
-void  VTransReadCheck (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
-{
-    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
-}
-
-void  VTransReadCheck (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
-{
-    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
-}
-
-void  VTransReadCheck (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
-{
-    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
-}
-
-void  VTransReadCheck (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
-{
-    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
-}
-
-void  VTransReadCheckData ( const uint8_t data, const uint32_t node)
-{
-    VTransCommon(READ_DATA_CHECK, (uint32_t)0, data, &unusedstatus, (uint32_t)0, node);
-}
-
-void  VTransReadCheckData (const uint16_t data, const uint32_t node)
-{
-    VTransCommon(READ_DATA_CHECK, (uint32_t)0, data, &unusedstatus, (uint32_t)0, node);
-}
-
-void  VTransReadCheckData (const uint32_t data, const uint32_t node)
-{
-    VTransCommon(READ_DATA_CHECK, (uint32_t)0, data, &unusedstatus, (uint32_t)0, node);
-}
-
-void  VTransReadCheckData (const uint64_t data, const uint32_t node)
-{
-    VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &unusedstatus, (uint32_t)0, node);
-}
-
-bool  VTransTryReadCheckData ( const uint8_t data, const uint32_t node)
-{
-    int status;
-
-    VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node);
-
-    return status;
-}
-
-bool  VTransTryReadCheckData (const uint16_t data, const uint32_t node)
-{
-    int status;
-
-    VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node);
-
-    return status;
-}
-
-bool  VTransTryReadCheckData (const uint32_t data, const uint32_t node)
-{
-    int status;
-
-    VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node);
-
-    return status;
-}
-
-bool  VTransTryReadCheckData (const uint64_t data, const uint32_t node)
-{
-    int status;
-
-    VTransCommon(ASYNC_READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);
-
-    return status;
-}
-
-void VTransBurstWrite (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWrite (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWrite (const uint32_t addr, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_TRANS, addr, NULL, bytesize, prot, node);
-}
-
-void VTransBurstWrite (const uint64_t addr, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_TRANS, addr, NULL, bytesize, prot, node);
-}
-
-void VTransBurstWriteAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteIncrement (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteIncrement (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteIncrementAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteIncrementAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteRandom (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteRandom (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteRandomAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstWriteRandomAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstPushData (uint8_t *data, const int count, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_DATA, (uint32_t)0, data, count, (uint32_t)0, node);
-}
-
-void VTransBurstPushIncrement (uint8_t *data, const int count, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_INCR_PUSH, (uint32_t)0, data, count, (uint32_t)0, node);
-}
-
-void VTransBurstPushRandom    (uint8_t *data, const int count, const uint32_t node)
-{
-    VTransBurstCommon(WRITE_BURST, BURST_RAND_PUSH, (uint32_t)0, data, count, (uint32_t)0, node);
-}
-
-void VTransCheckBurstReadIncrement (const uint32_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_INCR, addr, data, bytesize, prot, node);
-}
-
-void VTransCheckBurstReadIncrement (const uint64_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
-{
-     VTransBurstCommon(READ_BURST, BURST_INCR, addr, data, bytesize, prot, node);
-}
-
-void VTransCheckBurstReadRandom    (const uint32_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
-{
-     VTransBurstCommon(READ_BURST, BURST_RAND, addr, data, bytesize, prot, node);
-}
-
-void VTransCheckBurstReadRandom    (const uint64_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
-{
-     VTransBurstCommon(READ_BURST, BURST_RAND, addr, data, bytesize, prot, node);
-}
-
-void VTransCheckBurstIncrement (uint8_t *data, const int bytesize, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_INCR_CHECK, (uint32_t)0, data, bytesize, (uint32_t)0, node);
-}
-
-void VTransCheckBurstRandom    (uint8_t *data, const int bytesize, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_RAND_CHECK, (uint32_t)0, data, bytesize, (uint32_t)0, node);
-}
-
-void VTransCheckBurstData    (uint8_t *data, const int bytesize, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_DATA, (uint32_t)0, data, bytesize, (uint32_t)0, node);
-}
-
-void VTransBurstRead  (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_NORM, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstRead  (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_NORM, addr, data, bytesize, prot, node);
-}
-
-void VTransBurstRead  (const uint32_t addr, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_TRANS, addr, 0, bytesize, prot, node);
-}
-
-void VTransBurstRead  (const uint64_t addr, const int bytesize, const int prot, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_TRANS, addr, 0, bytesize, prot, node);
-}
-
-void VTransBurstPopData (uint8_t *data, const int bytesize, const uint32_t node)
-{
-    VTransBurstCommon(READ_BURST, BURST_DATA, (uint32_t)0, data, bytesize, 0, node);
-}
-
-// --------------------------------------------------------------------------------
-// Overloaded stream functions
-// --------------------------------------------------------------------------------
-
-void VStreamGet (uint8_t *rdata, int *status, const uint32_t node)
-{
-    VStreamGetCommon(GET, rdata, status, 0, 0, node);
-}
-
-bool VStreamTryGet (uint8_t *rdata, int *status, const uint32_t node)
-{
-    return VStreamGetCommon(TRY_GET, rdata, status, 0, 0, node);
-}
-
-bool VStreamTryCheck (uint8_t data, const int param, const uint32_t node)
-{
-    int status;
-
-    return VStreamGetCommon(TRY_CHECK, null, &status, data, param, node);
-}
-
-void VStreamGet (uint16_t *rdata, int *status, const uint32_t node)
-{
-    VStreamGetCommon(GET, rdata, status, 0, 0, node);
-}
-
-bool VStreamTryGet (uint16_t *rdata, int *status, const uint32_t node)
-{
-    return VStreamGetCommon(TRY_GET, rdata, status, 0, 0, node);
-}
-
-bool VStreamTryCheck (uint16_t data, const int param, const uint32_t node)
-{
-    int status;
-
-    return VStreamGetCommon(TRY_CHECK, null, &status, data, param, node);
-}
-
-void VStreamGet (uint32_t *rdata, int *status, const uint32_t node)
-{
-    VStreamGetCommon(GET, rdata, status, 0, 0, node);
-}
-
-bool VStreamTryGet (uint32_t *rdata, int *status, const uint32_t node)
-{
-    return VStreamGetCommon(TRY_GET, rdata, status, 0, 0, node);
-}
-
-bool VStreamTryCheck (uint32_t data, const int param, const uint32_t node)
-{
-    int status;
-    return VStreamGetCommon(TRY_CHECK, null, &status, data, param, node);
-}
-
-void VStreamGet (uint64_t *rdata, int *status, const uint32_t node)
-{
-    VStreamGetCommon(GET, rdata, status, 0, 0, node);
-}
-
-bool VStreamTryGet (uint64_t *rdata, int *status, const uint32_t node)
-{
-    return VStreamGetCommon(TRY_GET, rdata, status, 0, 0, node);
-}
-
-bool VStreamTryCheck (uint64_t data, const int param, const uint32_t node)
-{
-    int status;
-    return VStreamGetCommon(TRY_CHECK, null, &status, data, param, node);
-}
-
-uint8_t VStreamSend (const uint8_t data, const int param, const uint32_t node)
-{
-    return VStreamCommon(SEND, data, param, node);
-}
-
-uint16_t VStreamSend (const uint16_t data, const int param, const uint32_t node)
-{
-    return VStreamCommon(SEND, data, param, node);
-}
-
-uint32_t VStreamSend (const uint32_t data, const int param, const uint32_t node)
-{
-    return VStreamCommon(SEND, data, param, node);
-}
-
-uint64_t VStreamSend (const uint64_t data, const int param, const uint32_t node)
-{
-    return VStreamCommon(SEND, data, param, node);
-}
-
-uint8_t VStreamSendAsync (const uint8_t data, const int param, const uint32_t node)
-{
-    return VStreamCommon(SEND_ASYNC, data, param, node);
-}
-
-uint16_t VStreamSendAsync (const uint16_t data, const int param, const uint32_t node)
-{
-    return VStreamCommon(SEND_ASYNC, data, param, node);
-}
-
-uint32_t VStreamSendAsync (const uint32_t data, const int param, const uint32_t node)
-{
-    return VStreamCommon(SEND_ASYNC, data, param, node);
-}
-
-uint64_t VStreamSendAsync (const uint64_t data, const int param, const uint32_t node)
-{
-    return VStreamCommon(SEND_ASYNC, data, param, node);
-}
-
-void VStreamCheck (const uint8_t data, const int param, const uint32_t node)
-{
-    VStreamCommon(CHECK, data, param, node);
-}
-
-void VStreamCheck (const uint16_t data, const int param, const uint32_t node)
-{
-    VStreamCommon(CHECK, data, param, node);
-}
-
-void VStreamCheck (const uint32_t data, const int param, const uint32_t node)
-{
-    VStreamCommon(CHECK, data, param, node);
-}
-
-void VStreamCheck (const uint64_t data, const int param, const uint32_t node)
-{
-    VStreamCommon(CHECK, data, param, node);
-}
-
-void VStreamBurstSend (uint8_t* data, const int bytesize, const int param, const uint32_t node)
-{
-    VStreamBurstSendCommon(SEND_BURST, BURST_NORM, data, bytesize, param, node);
-}
-
-void VStreamBurstSend (const int bytesize, const int param, const uint32_t node)
-{
-    VStreamBurstSendCommon(SEND_BURST, BURST_TRANS, null, bytesize, param, node);
-}
-
-void VStreamBurstSendAsync (uint8_t* data, const int bytesize, const int param, const uint32_t node)
-{
-    VStreamBurstSendCommon(SEND_BURST_ASYNC, BURST_NORM, data, bytesize, param, node);
-}
-
-void VStreamBurstSendAsync (const int bytesize, const int param, const uint32_t node)
-{
-    VStreamBurstSendCommon(SEND_BURST_ASYNC, BURST_TRANS, null, bytesize, param, node);
-}
-
-void VStreamBurstCheck (uint8_t* data, const int bytesize, const int param, const uint32_t node)
-{
-    VStreamBurstSendCommon(CHECK_BURST, BURST_NORM, data, bytesize, param, node);
-}
-
-void VStreamBurstCheck (const int bytesize, const int param, const uint32_t node)
-{
-    VStreamBurstSendCommon(CHECK_BURST, BURST_TRANS, null, bytesize, param, node);
-}
-
-void VStreamBurstSendIncrement (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
-{
-    VStreamBurstSendCommon(SEND_BURST, BURST_INCR, data, bytesize, param, node);
-}
-
-void VStreamBurstSendIncrementAsync (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
-{
-    VStreamBurstSendCommon(SEND_BURST_ASYNC, BURST_INCR, data, bytesize, param, node);
-}
-
-void VStreamBurstCheckIncrement (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
-{
-    VStreamBurstSendCommon(CHECK_BURST, BURST_INCR_CHECK, data, bytesize, param, node);
-}
-
-void VStreamBurstSendRandom (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
-{
-    VStreamBurstSendCommon(CHECK_BURST, BURST_RAND, data, bytesize, param, node);
-}
-
-void VStreamBurstSendRandomAsync (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
-{
-    VStreamBurstSendCommon(SEND_BURST_ASYNC, BURST_RAND, data, bytesize, param, node);
-}
-
-void VStreamBurstCheckRandom (uint8_t  *data, const int  bytesize, const int  param, const uint32_t node)
-{
-    VStreamBurstSendCommon(CHECK_BURST, BURST_RAND_CHECK, data, bytesize, param, node);
-}
-
-void VStreamBurstPushData(uint8_t* data, const int bytesize, const uint32_t node)
-{
-
-    VStreamBurstSendCommon(SEND_BURST, BURST_DATA, data, bytesize, 0, node);
-}
-
-void VStreamBurstPushCheckData(uint8_t* data, const int bytesize, const uint32_t node)
-{
-
-    VStreamBurstSendCommon(CHECK_BURST, BURST_DATA, data, bytesize, 0, node);
-}
-
-void VStreamBurstPushIncrement(uint8_t* data, const int bytesize, const uint32_t node)
-{
-
-    VStreamBurstSendCommon(SEND_BURST, BURST_INCR_PUSH, data, bytesize, 0, node);
-}
-
-void VStreamBurstPushCheckIncrement(uint8_t* data, const int bytesize, const uint32_t node)
-{
-
-    VStreamBurstSendCommon(CHECK_BURST, BURST_INCR_PUSH, data, bytesize, 0, node);
-}
-
-void VStreamBurstPushRandom(uint8_t* data, const int bytesize, const uint32_t node)
-{
-
-    VStreamBurstSendCommon(SEND_BURST, BURST_RAND_PUSH, data, bytesize, 0, node);
-}
-
-void VStreamBurstPushCheckRandom(uint8_t* data, const int bytesize, const uint32_t node)
-{
-
-    VStreamBurstSendCommon(CHECK_BURST, BURST_RAND_PUSH, data, bytesize, 0, node);
-}
-
-bool VStreamBurstTryCheck (uint8_t *data, const int bytesize, const int param, const uint32_t node)
-{
-    return VStreamBurstSendCommon(TRY_CHECK_BURST, BURST_NORM, data, bytesize, param, node);
-}
-
-bool VStreamBurstTryCheck (const int bytesize, const int param, const uint32_t node)
-{
-    return VStreamBurstSendCommon(TRY_CHECK_BURST, BURST_TRANS, null, bytesize, param, node);
-}
-
-bool VStreamBurstTryCheckIncrement (uint8_t *data, const int bytesize, const int param, const uint32_t node)
-{
-    return VStreamBurstSendCommon(TRY_CHECK_BURST, BURST_INCR_CHECK, data, bytesize, param, node);
-}
-
-bool VStreamBurstTryCheckRandom (uint8_t *data, const int bytesize, const int param, const uint32_t node)
-{
-    return VStreamBurstSendCommon(TRY_CHECK_BURST, BURST_RAND_CHECK, data, bytesize, param, node);
-}
-
-void VStreamBurstGet (uint8_t* data, const int bytesize, int* status, const uint32_t node)
-{
-    VStreamBurstGetCommon(GET_BURST, BURST_NORM, data, bytesize, status, node);
-}
-
-void VStreamBurstGet (const int bytesize, int* status, const uint32_t node)
-{
-    VStreamBurstGetCommon(GET_BURST, BURST_TRANS, null, bytesize, status, node);
-}
-
-void VStreamBurstPopData(uint8_t* data, const int bytesize, const uint32_t node)
-{
-    int status;
-
-    VStreamBurstGetCommon(GET_BURST, BURST_DATA, data, bytesize, &status, node);
-}
-
-bool VStreamBurstTryGet   (uint8_t  *data, const int  bytesize, const int param, const uint32_t node)
-{
-    int status;
-
-    return VStreamBurstGetCommon(TRY_GET_BURST, BURST_NORM, data, bytesize, &status, node);
-}
-
-bool VStreamBurstTryGet (const int bytesize, const int param, const uint32_t node)
-{
-    int status;
-
-    return VStreamBurstGetCommon(TRY_GET_BURST, BURST_TRANS, null, bytesize, &status, node);
-}
 

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -70,7 +70,7 @@ typedef void*     symhdl_t;
 typedef void*     symhdl_t;
 #endif
 
-#if defined (ACTIVEHDL) || defined(SIEMENS)
+#if defined (ACTIVEHDL) || defined(SIEMENS) || (defined(ALDEC) && !defined(_WIN32))
 static symhdl_t hdlvp;
 #endif
 
@@ -161,7 +161,7 @@ static void VUserInit (const int node)
         exit(1);
     }
 
-#if defined(ACTIVEHDL) || defined(SIEMENS)
+#if defined(ACTIVEHDL) || defined(SIEMENS) || (defined(ALDEC) && !defined(_WIN32))
     // Close the VProc.so handle to decrement the count, incremented with the open
     dlclose(hdlvp);
 #endif
@@ -199,7 +199,7 @@ extern "C" int VUser (const int node)
 
     DebugVPrint("VUser(): initialised interrupt table node %d\n", node);
 
-#if defined(ACTIVEHDL) || defined (SIEMENS)
+#if defined(ACTIVEHDL) || defined (SIEMENS) || (defined(ALDEC) && !defined(_WIN32))
     // Load VProc shared object to make symbols global
     hdlvp = dlopen("./VProc.so", RTLD_LAZY | RTLD_GLOBAL);
 

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -531,12 +531,12 @@ static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 }
 
 // -------------------------------------------------------------------------
-// VTransBurstWriteCommon()
+// VTransBurstCommon()
 //
 // Invokes a write burst transaction exchange (32-bit address)
 // -------------------------------------------------------------------------
 
-static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+static void VTransBurstCommon (const addr_bus_trans_op_t op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -563,12 +563,12 @@ static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const int para
 }
 
 // -------------------------------------------------------------------------
-// VTransBurstWriteCommon()
+// VTransBurstCommon()
 //
 // Invokes a write burst transaction exchange (64-bit address)
 // -------------------------------------------------------------------------
 
-static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+static void VTransBurstCommon (const addr_bus_trans_op_t op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -1309,7 +1309,6 @@ void  VTransReadCheckData (const uint64_t data, const uint32_t node)
     VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &unusedstatus, (uint32_t)0, node);
 }
 
-
 bool  VTransTryReadCheckData ( const uint8_t data, const uint32_t node)
 {
     int status;
@@ -1348,83 +1347,102 @@ bool  VTransTryReadCheckData (const uint64_t data, const uint32_t node)
 
 void VTransBurstWrite (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
+    VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWrite (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
+    VTransBurstCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
+    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
+    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteIncrement (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+    VTransBurstCommon(WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteIncrement (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+    VTransBurstCommon(WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteIncrementAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteIncrementAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteRandom (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+    VTransBurstCommon(WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteRandom (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+    VTransBurstCommon(WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteRandomAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteRandomAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+    VTransBurstCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
 }
 
+void VTransBurstPushIncrement (uint8_t *data, const int count, const uint32_t node)
+{
+    VTransBurstCommon(WRITE_BURST, BURST_INCR_PUSH, (uint32_t)0, data, count, (uint32_t)0, node);
+}
+
+void VTransBurstPushRandom    (uint8_t *data, const int count, const uint32_t node)
+{
+    VTransBurstCommon(WRITE_BURST, BURST_RAND_PUSH, (uint32_t)0, data, count, (uint32_t)0, node);
+}
 
 void VTransCheckBurstReadIncrement (const uint32_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(READ_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+    VTransBurstCommon(READ_BURST, BURST_INCR, addr, data, bytesize, prot, node);
 }
 
 void VTransCheckBurstReadIncrement (const uint64_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
 {
-     VTransBurstWriteCommon(READ_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+     VTransBurstCommon(READ_BURST, BURST_INCR, addr, data, bytesize, prot, node);
 }
 
 void VTransCheckBurstReadRandom    (const uint32_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
 {
-     VTransBurstWriteCommon(READ_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+     VTransBurstCommon(READ_BURST, BURST_RAND, addr, data, bytesize, prot, node);
 }
 
 void VTransCheckBurstReadRandom    (const uint64_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
 {
-     VTransBurstWriteCommon(READ_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+     VTransBurstCommon(READ_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+}
+
+void VTransCheckBurstIncrement (uint8_t *data, const int bytesize, const uint32_t node)
+{
+    VTransBurstCommon(READ_BURST, BURST_INCR_CHECK, (uint32_t)0, data, bytesize, (uint32_t)0, node);
+}
+
+void VTransCheckBurstRandom    (uint8_t *data, const int bytesize, const uint32_t node)
+{
+    VTransBurstCommon(READ_BURST, BURST_RAND_CHECK, (uint32_t)0, data, bytesize, (uint32_t)0, node);
 }
 
 // --------------------------------------------------------------------------------

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -73,6 +73,8 @@ static std::mutex acc_mx[VP_MAX_NODES];
 static symhdl_t hdlvp;
 #endif
 
+static int unusedstatus;
+
 // -------------------------------------------------------------------------
 // VInitSendBuf()
 //
@@ -89,6 +91,7 @@ static void VInitSendBuf(send_buf_t &sbuf)
     sbuf.ticks           = 0;
     sbuf.done            = 0;
     sbuf.error           = 0;
+    sbuf.param           = 0;
 }
 
 // -------------------------------------------------------------------------
@@ -339,7 +342,7 @@ void VWaitForSim(const uint32_t node)
 //
 // -------------------------------------------------------------------------
 
-static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
+static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -355,6 +358,8 @@ static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, 
 
     VExch(&sbuf, &rbuf, node);
 
+    *status = rbuf.status;
+
     return rbuf.data_in & 0xffU;
 }
 
@@ -364,7 +369,7 @@ static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, 
 // Invokes an 16-bit transaction exchange
 //
 // -------------------------------------------------------------------------
-static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint16_t data, int const prot, const uint32_t node)
+static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint16_t data,  int* status, int const prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -380,6 +385,8 @@ static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr,
 
     VExch(&sbuf, &rbuf, node);
 
+    *status = rbuf.status;
+
     return rbuf.data_in & 0xffffU;
 }
 
@@ -390,7 +397,7 @@ static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr,
 //
 // -------------------------------------------------------------------------
 
-static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
+static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr, const uint32_t data, int* status,  const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -406,6 +413,8 @@ static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr,
 
     VExch(&sbuf, &rbuf, node);
 
+    *status = rbuf.status;
+
     return rbuf.data_in;
 }
 
@@ -416,7 +425,7 @@ static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint32_t addr,
 //
 // -------------------------------------------------------------------------
 
-static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
+static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -432,6 +441,8 @@ static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, 
 
     VExch(&sbuf, &rbuf, node);
 
+    *status = rbuf.status;
+
     return rbuf.data_in & 0xffU;
 }
 
@@ -442,7 +453,7 @@ static uint8_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, 
 //
 // -------------------------------------------------------------------------
 
-static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
+static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint16_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -458,6 +469,8 @@ static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 
     VExch(&sbuf, &rbuf, node);
 
+    *status = rbuf.status;
+
     return rbuf.data_in & 0xffffU;
 }
 
@@ -468,7 +481,7 @@ static uint16_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 //
 // -------------------------------------------------------------------------
 
-static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
+static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint32_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -484,6 +497,8 @@ static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 
     VExch(&sbuf, &rbuf, node);
 
+    *status = rbuf.status;
+
     return rbuf.data_in;
 }
 
@@ -494,7 +509,7 @@ static uint32_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 //
 // -------------------------------------------------------------------------
 
-static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
+static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr, const uint64_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -510,6 +525,8 @@ static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 
     VExch(&sbuf, &rbuf, node);
 
+    *status = rbuf.status;
+
     return (uint64_t)rbuf.data_in | ((uint64_t)rbuf.data_in_hi << 32);
 }
 
@@ -519,7 +536,7 @@ static uint64_t VTransCommon (const addr_bus_trans_op_t op, const uint64_t addr,
 // Invokes a write burst transaction exchange (32-bit address)
 // -------------------------------------------------------------------------
 
-static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -530,9 +547,12 @@ static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const uint32_t
     sbuf.addr            = addr;
     sbuf.prot            = prot;
     sbuf.op              = op;
+    sbuf.param           = param;
     sbuf.num_burst_bytes = bytesize % DATABUF_SIZE;
 
-    for (int idx = 0; idx < sbuf.num_burst_bytes; idx++)
+    int num_of_wr_bytes = (param == BURST_NORM) ? sbuf.num_burst_bytes : 1;
+
+    for (int idx = 0; idx < num_of_wr_bytes; idx++)
     {
         sbuf.databuf[idx] = data[idx];
     }
@@ -548,7 +568,7 @@ static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const uint32_t
 // Invokes a write burst transaction exchange (64-bit address)
 // -------------------------------------------------------------------------
 
-static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -559,9 +579,12 @@ static void VTransBurstWriteCommon (const addr_bus_trans_op_t op, const uint64_t
     sbuf.addr            = addr;
     sbuf.prot            = prot;
     sbuf.op              = op;
+    sbuf.param           = param;
     sbuf.num_burst_bytes = bytesize % DATABUF_SIZE;
 
-    for (int idx = 0; idx < sbuf.num_burst_bytes; idx++)
+    int num_of_wr_bytes = (param == BURST_NORM) ? sbuf.num_burst_bytes : 1;
+
+    for (int idx = 0; idx < num_of_wr_bytes; idx++)
     {
         sbuf.databuf[idx] = data[idx];
     }
@@ -962,258 +985,450 @@ void VSetTestName (const char* data, const int bytesize, const uint32_t node)
 
 void VTransRead (const uint32_t addr, uint8_t *rdata, const int prot, const uint32_t node)
 {
-    *rdata = VTransCommon(READ_OP, addr, (uint8_t)0, prot, node);
+    *rdata = VTransCommon(READ_OP, addr, (uint8_t)0, &unusedstatus, prot, node);
 }
 
 void VTransRead (const uint32_t addr, uint16_t *rdata, const int prot, const uint32_t node)
 {
-    *rdata = VTransCommon(READ_OP, addr, (uint16_t)0, prot, node);
+    *rdata = VTransCommon(READ_OP, addr, (uint16_t)0, &unusedstatus, prot, node);
 }
 
 void VTransRead (const uint32_t addr, uint32_t *rdata, const int prot, const uint32_t node)
 {
-    *rdata = VTransCommon(READ_OP, addr, (uint32_t)0, prot, node);
+    *rdata = VTransCommon(READ_OP, addr, (uint32_t)0, &unusedstatus, prot, node);
 }
 
 void VTransRead (const uint64_t addr, uint8_t *rdata, const int prot, const uint32_t node)
 {
-    *rdata = VTransCommon(READ_OP, addr, (uint8_t)0, prot, node);
+    *rdata = VTransCommon(READ_OP, addr, (uint8_t)0, &unusedstatus, prot, node);
 }
 
 void VTransRead (const uint64_t addr, uint16_t *rdata, const int prot, const uint32_t node)
 {
-    *rdata = VTransCommon(READ_OP, addr, (uint16_t)0, prot, node);
+    *rdata = VTransCommon(READ_OP, addr, (uint16_t)0, &unusedstatus, prot, node);
 }
 
 void VTransRead (const uint64_t addr, uint32_t *rdata, const int prot, const uint32_t node)
 {
-    *rdata = VTransCommon(READ_OP, addr, (uint32_t)0, prot, node);
+    *rdata = VTransCommon(READ_OP, addr, (uint32_t)0, &unusedstatus, prot, node);
 }
 
 void VTransRead (const uint64_t addr, uint64_t *rdata, const int prot, const uint32_t node)
 {
-    *rdata = VTransCommon(READ_OP, addr, (uint64_t)0, prot, node);
+    *rdata = VTransCommon(READ_OP, addr, (uint64_t)0, &unusedstatus, prot, node);
 }
 
 uint8_t VTransWrite (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_OP, addr, data, prot, node);
+     return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
 }
 
 uint8_t VTransWriteAsync (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
 }
 
 uint16_t VTransWrite (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_OP, addr, data, prot, node);
+     return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
 }
 
 uint16_t VTransWriteAsync (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
 }
 
 uint32_t VTransWrite (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_OP, addr, data, prot, node);
+     return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
 }
 
 uint32_t VTransWriteAsync (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
 }
 
 uint8_t VTransWrite (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_OP, addr, data, prot, node);
+     return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
 }
 
 uint8_t VTransWriteAsync (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
 }
 
 uint16_t VTransWrite (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_OP, addr, data, prot, node);
+     return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
 }
 
 uint16_t VTransWriteAsync (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
 }
 
 uint32_t VTransWrite (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_OP, addr, data, prot, node);
+     return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
 }
 
 uint32_t VTransWriteAsync (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
 }
 
 uint64_t VTransWrite (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_OP, addr, data, prot, node);
+     return VTransCommon(WRITE_OP, addr, data, &unusedstatus, prot, node);
 }
 
 uint64_t VTransWriteAsync (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE, addr, data, &unusedstatus, prot, node);
 }
 
 uint8_t VTransWriteAndRead (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint8_t VTransWriteAndReadAsync (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint16_t VTransWriteAndRead (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint16_t VTransWriteAndReadAsync (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint32_t VTransWriteAndRead (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint32_t VTransWriteAndReadAsync (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint8_t VTransWriteAndRead (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint8_t VTransWriteAndReadAsync (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint16_t VTransWriteAndRead (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint16_t VTransWriteAndReadAsync (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint32_t VTransWriteAndRead (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint32_t VTransWriteAndReadAsync (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint64_t VTransWriteAndRead (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 uint64_t VTransWriteAndReadAsync (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
 {
-     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, prot, node);
+     return VTransCommon(ASYNC_WRITE_AND_READ, addr, data, &unusedstatus, prot, node);
 }
 
 void VTransWriteAddressAsync (const uint32_t addr, const uint32_t node)
 {
-    VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, 0, node);
+    VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &unusedstatus, 0, node);
 }
 
 void VTransWriteAddressAsync (const uint64_t addr, const uint32_t node)
 {
-    VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, 0, node);
+    VTransCommon(ASYNC_WRITE_ADDRESS, addr, (uint32_t)0, &unusedstatus, 0, node);
 }
 
 void VTransWriteDataAsync (const uint8_t  data, const uint32_t bytelane, const uint32_t node)
 {
-    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, 0, node);
+    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &unusedstatus, 0, node);
 }
 
 void VTransWriteDataAsync (const uint16_t data, const uint32_t bytelane, const uint32_t node)
 {
-    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, 0, node);
+    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &unusedstatus, 0, node);
 }
 
 void VTransWriteDataAsync (const uint32_t data, const uint32_t bytelane, const uint32_t node)
 {
-    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, 0, node);
+    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &unusedstatus, 0, node);
 }
 
 void VTransWriteDataAsync (const uint64_t data, const uint64_t bytelane, const uint32_t node)
 {
-    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, 0, node);
+    VTransCommon(ASYNC_WRITE_DATA, bytelane, data, &unusedstatus, 0, node);
 }
 
 void VTransReadAddressAsync  (const uint32_t addr, const uint32_t node)
 {
-    VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, 0, node);
+    VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &unusedstatus, 0, node);
 }
 
 void VTransReadAddressAsync  (const uint64_t addr, const uint32_t node)
 {
-    VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, 0, node);
+    VTransCommon(ASYNC_READ_ADDRESS, addr, (uint32_t)0, &unusedstatus, 0, node);
 }
 
 void VTransReadData (uint8_t  *data, const uint32_t node)
 {
-    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, 0, node);
+    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint8_t)0, &unusedstatus, 0, node);
 }
 
 void VTransReadData (uint16_t *data, const uint32_t node)
 {
-    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint16_t)0, 0, node);
+    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint16_t)0, &unusedstatus, 0, node);
 }
 
 void VTransReadData (uint32_t *data, const uint32_t node)
 {
-    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint32_t)0, 0, node);
+    *data = VTransCommon(READ_DATA, (uint32_t)0, (uint32_t)0, &unusedstatus, 0, node);
 }
 
 void VTransReadData (uint64_t  *data, const uint32_t node)
 {
-    *data = VTransCommon(READ_DATA, (uint64_t)0, (uint64_t)0, 0, node);
+    *data = VTransCommon(READ_DATA, (uint64_t)0, (uint64_t)0, &unusedstatus, 0, node);
+}
+
+bool VTransTryReadData (uint8_t *data, const uint32_t node)
+{
+    int status;
+
+    *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint8_t)0, &status, 0, node);
+
+    return status;
+}
+
+bool VTransTryReadData (uint16_t *data, const uint32_t node)
+{
+    int status;
+
+    *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint16_t)0, &status, 0, node);
+
+    return status;
+}
+
+bool VTransTryReadData (uint32_t *data, const uint32_t node)
+{
+    int status;
+
+    *data = VTransCommon(ASYNC_READ_DATA, (uint32_t)0, (uint32_t)0, &status, 0, node);
+
+    return status;
+}
+
+bool VTransTryReadData (uint64_t *data, const uint32_t node)
+{
+    int status;
+
+    *data = VTransCommon(ASYNC_READ_DATA, (uint64_t)0, (uint64_t)0, &status, 0, node);
+
+    return status;
+}
+
+void  VTransReadCheck (const uint32_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
+}
+
+void  VTransReadCheck (const uint32_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
+}
+
+void  VTransReadCheck (const uint32_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
+}
+
+void  VTransReadCheck (const uint64_t addr, const uint8_t data, const int prot, const uint32_t node)
+{
+    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
+}
+
+void  VTransReadCheck (const uint64_t addr, const uint16_t data, const int prot, const uint32_t node)
+{
+    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
+}
+
+void  VTransReadCheck (const uint64_t addr, const uint32_t data, const int prot, const uint32_t node)
+{
+    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
+}
+
+void  VTransReadCheck (const uint64_t addr, const uint64_t data, const int prot, const uint32_t node)
+{
+    VTransCommon(READ_CHECK, addr, data, &unusedstatus, prot, node);
+}
+
+void  VTransReadCheckData ( const uint8_t data, const uint32_t node)
+{
+    VTransCommon(READ_DATA_CHECK, (uint32_t)0, data, &unusedstatus, (uint32_t)0, node);
+}
+
+void  VTransReadCheckData (const uint16_t data, const uint32_t node)
+{
+    VTransCommon(READ_DATA_CHECK, (uint32_t)0, data, &unusedstatus, (uint32_t)0, node);
+}
+
+void  VTransReadCheckData (const uint32_t data, const uint32_t node)
+{
+    VTransCommon(READ_DATA_CHECK, (uint32_t)0, data, &unusedstatus, (uint32_t)0, node);
+}
+
+void  VTransReadCheckData (const uint64_t data, const uint32_t node)
+{
+    VTransCommon(READ_DATA_CHECK, (uint64_t)0, data, &unusedstatus, (uint32_t)0, node);
+}
+
+
+bool  VTransTryReadCheckData ( const uint8_t data, const uint32_t node)
+{
+    int status;
+
+    VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node);
+
+    return status;
+}
+
+bool  VTransTryReadCheckData (const uint16_t data, const uint32_t node)
+{
+    int status;
+
+    VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node);
+
+    return status;
+}
+
+bool  VTransTryReadCheckData (const uint32_t data, const uint32_t node)
+{
+    int status;
+
+    VTransCommon(ASYNC_READ_DATA_CHECK, (uint32_t)0, data, &status, (uint32_t)0, node);
+
+    return status;
+}
+
+bool  VTransTryReadCheckData (const uint64_t data, const uint32_t node)
+{
+    int status;
+
+    VTransCommon(ASYNC_READ_DATA_CHECK, (uint64_t)0, data, &status, (uint32_t)0, node);
+
+    return status;
 }
 
 void VTransBurstWrite (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(WRITE_BURST, addr, data, bytesize, prot, node);
+    VTransBurstWriteCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWrite (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(WRITE_BURST, addr, data, bytesize, prot, node);
+    VTransBurstWriteCommon(WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(ASYNC_WRITE_BURST, addr, data, bytesize, prot, node);
+    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
 }
 
 void VTransBurstWriteAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
 {
-    VTransBurstWriteCommon(ASYNC_WRITE_BURST, addr, data, bytesize, prot, node);
+    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_NORM, addr, data, bytesize, prot, node);
 }
+
+void VTransBurstWriteIncrement (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteIncrement (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteIncrementAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteIncrementAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteRandom (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteRandom (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteRandomAsync (const uint32_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+}
+
+void VTransBurstWriteRandomAsync (const uint64_t addr, uint8_t* data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(ASYNC_WRITE_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+}
+
+
+void VTransCheckBurstReadIncrement (const uint32_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
+{
+    VTransBurstWriteCommon(READ_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+}
+
+void VTransCheckBurstReadIncrement (const uint64_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
+{
+     VTransBurstWriteCommon(READ_BURST, BURST_INCR, addr, data, bytesize, prot, node);
+}
+
+void VTransCheckBurstReadRandom    (const uint32_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
+{
+     VTransBurstWriteCommon(READ_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+}
+
+void VTransCheckBurstReadRandom    (const uint64_t addr, uint8_t *data, const int bytesize, const int prot, const uint32_t node)
+{
+     VTransBurstWriteCommon(READ_BURST, BURST_RAND, addr, data, bytesize, prot, node);
+}
+
+// --------------------------------------------------------------------------------
+// Overloaded stream functions
 
 uint8_t VStreamSend (const uint8_t data, const int param, const uint32_t node)
 {
@@ -1264,5 +1479,4 @@ void VStreamBurstSendAsync (uint8_t* data, const int bytesize, const uint32_t no
 {
     VStreamBurstSendCommon(SEND_BURST_ASYNC, data, bytesize, node);
 }
-
 

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -371,7 +371,7 @@ void VWaitForSim(const uint32_t node)
 //
 // -------------------------------------------------------------------------
 
-uint8_t VTransUserCommon (const int op, const uint32_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
+uint8_t VTransUserCommon (const int op, uint32_t *addr, const uint8_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -379,7 +379,7 @@ uint8_t VTransUserCommon (const int op, const uint32_t addr, const uint8_t data,
     VInitSendBuf(sbuf);
 
     sbuf.type            = trans32_byte;
-    sbuf.addr            = addr;
+    sbuf.addr            = *addr;
     sbuf.prot            = prot;
     sbuf.op              = (addr_bus_trans_op_t)op;
 
@@ -388,6 +388,7 @@ uint8_t VTransUserCommon (const int op, const uint32_t addr, const uint8_t data,
     VExch(&sbuf, &rbuf, node);
 
     *status = rbuf.status;
+    *addr   = rbuf.addr_in;
 
     return rbuf.data_in & 0xffU;
 }
@@ -399,7 +400,7 @@ uint8_t VTransUserCommon (const int op, const uint32_t addr, const uint8_t data,
 //
 // -------------------------------------------------------------------------
 
-uint16_t VTransUserCommon (const int op, const uint32_t addr, const uint16_t data,  int* status, int const prot, const uint32_t node)
+uint16_t VTransUserCommon (const int op, uint32_t *addr, const uint16_t data,  int* status, int const prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -407,7 +408,7 @@ uint16_t VTransUserCommon (const int op, const uint32_t addr, const uint16_t dat
     VInitSendBuf(sbuf);
 
     sbuf.type            = trans32_hword;
-    sbuf.addr            = addr;
+    sbuf.addr            = *addr;
     sbuf.prot            = prot;
     sbuf.op              = (addr_bus_trans_op_t)op;
 
@@ -416,6 +417,7 @@ uint16_t VTransUserCommon (const int op, const uint32_t addr, const uint16_t dat
     VExch(&sbuf, &rbuf, node);
 
     *status = rbuf.status;
+    *addr   = rbuf.addr_in;
 
     return rbuf.data_in & 0xffffU;
 }
@@ -427,7 +429,7 @@ uint16_t VTransUserCommon (const int op, const uint32_t addr, const uint16_t dat
 //
 // -------------------------------------------------------------------------
 
-uint32_t VTransUserCommon (const int op, const uint32_t addr, const uint32_t data, int* status,  const int prot, const uint32_t node)
+uint32_t VTransUserCommon (const int op, uint32_t *addr, const uint32_t data, int* status,  const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -435,7 +437,7 @@ uint32_t VTransUserCommon (const int op, const uint32_t addr, const uint32_t dat
     VInitSendBuf(sbuf);
 
     sbuf.type            = trans32_word;
-    sbuf.addr            = addr;
+    sbuf.addr            = *addr;
     sbuf.prot            = prot;
     sbuf.op              = (addr_bus_trans_op_t)op;
 
@@ -444,6 +446,7 @@ uint32_t VTransUserCommon (const int op, const uint32_t addr, const uint32_t dat
     VExch(&sbuf, &rbuf, node);
 
     *status = rbuf.status;
+    *addr   = rbuf.addr_in;
 
     return rbuf.data_in;
 }
@@ -455,7 +458,7 @@ uint32_t VTransUserCommon (const int op, const uint32_t addr, const uint32_t dat
 //
 // -------------------------------------------------------------------------
 
-uint8_t VTransUserCommon (const int op, const uint64_t addr, const uint8_t data, int* status, const int prot, const uint32_t node)
+uint8_t VTransUserCommon (const int op, uint64_t *addr, const uint8_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -463,7 +466,7 @@ uint8_t VTransUserCommon (const int op, const uint64_t addr, const uint8_t data,
     VInitSendBuf(sbuf);
 
     sbuf.type            = trans64_byte;
-    sbuf.addr            = addr;
+    sbuf.addr            = *addr;
     sbuf.prot            = prot;
     sbuf.op              = (addr_bus_trans_op_t)op;
 
@@ -472,6 +475,7 @@ uint8_t VTransUserCommon (const int op, const uint64_t addr, const uint8_t data,
     VExch(&sbuf, &rbuf, node);
 
     *status = rbuf.status;
+    *addr   = ((uint64_t)rbuf.addr_in_hi << 32) | ((uint64_t)rbuf.addr_in);
 
     return rbuf.data_in & 0xffU;
 }
@@ -483,7 +487,7 @@ uint8_t VTransUserCommon (const int op, const uint64_t addr, const uint8_t data,
 //
 // -------------------------------------------------------------------------
 
-uint16_t VTransUserCommon (const int op, const uint64_t addr, const uint16_t data, int* status, const int prot, const uint32_t node)
+uint16_t VTransUserCommon (const int op, uint64_t *addr, const uint16_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -491,7 +495,7 @@ uint16_t VTransUserCommon (const int op, const uint64_t addr, const uint16_t dat
     VInitSendBuf(sbuf);
 
     sbuf.type            = trans64_hword;
-    sbuf.addr            = addr;
+    sbuf.addr            = *addr;
     sbuf.prot            = prot;
     sbuf.op              = (addr_bus_trans_op_t)op;
 
@@ -500,6 +504,7 @@ uint16_t VTransUserCommon (const int op, const uint64_t addr, const uint16_t dat
     VExch(&sbuf, &rbuf, node);
 
     *status = rbuf.status;
+    *addr   = ((uint64_t)rbuf.addr_in_hi << 32) | ((uint64_t)rbuf.addr_in);
 
     return rbuf.data_in & 0xffffU;
 }
@@ -511,7 +516,7 @@ uint16_t VTransUserCommon (const int op, const uint64_t addr, const uint16_t dat
 //
 // -------------------------------------------------------------------------
 
-uint32_t VTransUserCommon (const int op, const uint64_t addr, const uint32_t data, int* status, const int prot, const uint32_t node)
+uint32_t VTransUserCommon (const int op, uint64_t *addr, const uint32_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -519,7 +524,7 @@ uint32_t VTransUserCommon (const int op, const uint64_t addr, const uint32_t dat
     VInitSendBuf(sbuf);
 
     sbuf.type            = trans64_word;
-    sbuf.addr            = addr;
+    sbuf.addr            = *addr;
     sbuf.prot            = prot;
     sbuf.op              = (addr_bus_trans_op_t)op;
 
@@ -528,6 +533,7 @@ uint32_t VTransUserCommon (const int op, const uint64_t addr, const uint32_t dat
     VExch(&sbuf, &rbuf, node);
 
     *status = rbuf.status;
+    *addr   = ((uint64_t)rbuf.addr_in_hi << 32) | ((uint64_t)rbuf.addr_in);
 
     return rbuf.data_in;
 }
@@ -539,7 +545,7 @@ uint32_t VTransUserCommon (const int op, const uint64_t addr, const uint32_t dat
 //
 // -------------------------------------------------------------------------
 
-uint64_t VTransUserCommon (const int op, const uint64_t addr, const uint64_t data, int* status, const int prot, const uint32_t node)
+uint64_t VTransUserCommon (const int op, uint64_t *addr, const uint64_t data, int* status, const int prot, const uint32_t node)
 {
     rcv_buf_t  rbuf;
     send_buf_t sbuf;
@@ -547,7 +553,7 @@ uint64_t VTransUserCommon (const int op, const uint64_t addr, const uint64_t dat
     VInitSendBuf(sbuf);
 
     sbuf.type            = trans64_dword;
-    sbuf.addr            = addr;
+    sbuf.addr            = *addr;
     sbuf.prot            = prot;
     sbuf.op              = (addr_bus_trans_op_t)op;
 
@@ -556,6 +562,7 @@ uint64_t VTransUserCommon (const int op, const uint64_t addr, const uint64_t dat
     VExch(&sbuf, &rbuf, node);
 
     *status = rbuf.status;
+    *addr   = ((uint64_t)rbuf.addr_in_hi << 32) | ((uint64_t)rbuf.addr_in);
 
     return (uint64_t)rbuf.data_in | ((uint64_t)rbuf.data_in_hi << 32);
 }
@@ -666,11 +673,11 @@ int VTransGetCount (const int op, const uint32_t node)
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
-    
+
     sbuf.op              = (addr_bus_trans_op_t)op;
-    
+
     VExch(&sbuf, &rbuf, node);
-    
+
     return rbuf.count;
 
 }
@@ -687,11 +694,11 @@ void VTransTransactionWait (const int op, const uint32_t node)
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
-    
+
     sbuf.op              = (addr_bus_trans_op_t)op;
-    
+
     VExch(&sbuf, &rbuf, node);
-    
+
     return;
 }
 
@@ -1005,12 +1012,12 @@ int VStreamWaitGetCount (const int op, const bool txnrx, const uint32_t node)
     send_buf_t sbuf;
 
     VInitSendBuf(sbuf);
-    
+
     sbuf.op                = (addr_bus_trans_op_t)op;
     *((uint32_t*)sbuf.data) = txnrx ? 1 : 0;
-    
+
     VExch(&sbuf, &rbuf, node);
-    
+
     return txnrx ? rbuf.countsec : rbuf.count;
 }
 

--- a/code/OsvvmVUser.cpp
+++ b/code/OsvvmVUser.cpp
@@ -49,14 +49,10 @@
 #include <unistd.h>
 #include <mutex>
 
-extern "C"
-{
 #include "OsvvmVProc.h"
-}
 #include "OsvvmVUser.h"
 
-#if defined(ALDEC)
-# if defined (_WIN32)
+#if defined(ALDEC) and defined (_WIN32)
 
 # include <windows.h>
 
@@ -77,10 +73,6 @@ extern "C"
 
 typedef HINSTANCE symhdl_t;
 
-# else
-typedef void*     symhdl_t;
-# endif
-
 #else
 typedef void*     symhdl_t;
 #endif
@@ -95,12 +87,6 @@ static std::mutex  acc_mx[VP_MAX_NODES];
 #else
 static std::mutex *acc_mx[VP_MAX_NODES];
 #endif
-
-// -------------------------------------------------------------------------
-// LOCAL STATICS
-// -------------------------------------------------------------------------
-
-static int unusedstatus;
 
 // -------------------------------------------------------------------------
 // FUNCTION DEFINITIONS
@@ -218,7 +204,7 @@ static void VUserInit (const int node)
 //
 // -------------------------------------------------------------------------
 
-extern "C" int VUser (const int node)
+int VUser (const int node)
 {
     pthread_t thread;
     int status;
@@ -1004,6 +990,10 @@ bool VStreamUserBurstGetCommon (const int op, const int param, uint8_t* data, co
 }
 
 // -------------------------------------------------------------------------
+// VStreamWaitGetCount()
+//
+// Common function for transaction wait and get count operation exchange
+//
 // -------------------------------------------------------------------------
 
 int VStreamWaitGetCount (const int op, const bool txnrx, const uint32_t node)

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -140,197 +140,34 @@ extern void     VWaitForSim                    (const uint32_t node = 0);
 // OSVVM support function to set the test name
 extern void     VSetTestName                   (const char*    data, const int bytesize, const uint32_t node);
 
-// Overloaded write transaction functions for 32 and 64 bit architecture for byte,
-// half-word, word and double-word
-extern uint8_t  VTransWrite                    (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWrite                    (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWrite                    (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint8_t  VTransWrite                    (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWrite                    (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWrite                    (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint64_t VTransWrite                    (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+// Overloaded transaction functions for 32 and 64 bit architecture for byte, half-word, word and double-word
+extern uint8_t  VTransCommon                   (const int op, const uint32_t addr, const uint8_t data,  int* status, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransCommon                   (const int op, const uint32_t addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransCommon                   (const int op, const uint32_t addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransCommon                   (const int op, const uint64_t addr, const uint8_t  data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransCommon                   (const int op, const uint64_t addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransCommon                   (const int op, const uint64_t addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint64_t VTransCommon                   (const int op, const uint64_t addr, const uint64_t data, int* status, const int prot = 0, const uint32_t node = 0);
 
-// Overloaded write asynchronous transaction functions for 32 and 64 bit architecture for byte,
-// half-word, word and double-word
-extern uint8_t  VTransWriteAsync               (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWriteAsync               (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWriteAsync               (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint8_t  VTransWriteAsync               (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWriteAsync               (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWriteAsync               (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint64_t VTransWriteAsync               (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+// Overloaded stream transaction functions for 32 and 64 bit architecture
+extern void     VTransBurstCommon              (const int op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstCommon              (const int op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 
-// Overloaded read transaction functions for 32 and 64 bit architecture for byte,
-// half-word, word, and double-word
-extern void     VTransRead                     (const uint32_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                     (const uint32_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                     (const uint32_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                     (const uint64_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                     (const uint64_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                     (const uint64_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                     (const uint64_t addr,       uint64_t *data, const int prot = 0, const uint32_t node = 0);
+// Overloaded stream send/check common transaction functions for byte, half-word, word and double-word
+extern uint8_t  VStreamCommon                  (const int op, const uint8_t   data,    const int  param = 0,  const uint32_t node = 0);
+extern uint16_t VStreamCommon                  (const int op, const uint16_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern uint32_t VStreamCommon                  (const int op, const uint32_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern uint64_t VStreamCommon                  (const int op, const uint64_t  data,    const int  param = 0,  const uint32_t node = 0);
 
-extern void     VTransReadCheck                (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck                (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck                (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck                (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck                (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck                (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck                (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
-
-// Overloaded write-read transaction functions for 32 and 64 bit architecture for byte,
-// half-word, word and double-word
-uint8_t         VTransWriteAndRead             (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndRead             (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndRead             (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint8_t         VTransWriteAndRead             (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndRead             (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndRead             (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint64_t        VTransWriteAndRead             (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
-
-// Overloaded write-read asynchronous transaction functions for 32 and 64 bit architecture for byte,
-// half-word, word and double-word
-uint8_t         VTransWriteAndReadAsync        (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndReadAsync        (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndReadAsync        (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint8_t         VTransWriteAndReadAsync        (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndReadAsync        (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndReadAsync        (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint64_t        VTransWriteAndReadAsync        (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
-
-// Overloaded write address asynchronous transaction functions for 32 and 64 bit architecture
-void            VTransWriteAddressAsync        (const uint32_t addr, const uint32_t node = 0);
-void            VTransWriteAddressAsync        (const uint64_t addr, const uint32_t node = 0);
-
-// Overloaded write data transaction functions for byte, half-word, word and double-word
-void            VTransWriteDataAsync           (const uint8_t  data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync           (const uint16_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync           (const uint32_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync           (const uint64_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
-
-// Overloaded read address asynchronous tr     ansaction functions for 32 and 64 bit architecture
-void            VTransReadAddressAsync         (const uint32_t addr, const uint32_t node = 0);
-void            VTransReadAddressAsync         (const uint64_t addr, const uint32_t node = 0);
-
-// Overloaded write data transaction functions for byte, half-word, word and double-word
-void            VTransReadData                 (     uint8_t  *data, const uint32_t node = 0);
-void            VTransReadData                 (     uint16_t *data, const uint32_t node = 0);
-void            VTransReadData                 (     uint32_t *data, const uint32_t node = 0);
-void            VTransReadData                 (     uint64_t *data, const uint32_t node = 0);
-
-bool            VTransTryReadData              (     uint8_t  *data, const uint32_t node = 0);
-bool            VTransTryReadData              (     uint16_t *data, const uint32_t node = 0);
-bool            VTransTryReadData              (     uint32_t *data, const uint32_t node = 0);
-bool            VTransTryReadData              (     uint64_t *data, const uint32_t node = 0);
-
-// Overloaded write data transaction functions for byte, half-word, word and double-word
-void            VTransReadCheckData            (const uint8_t  data, const uint32_t node = 0);
-void            VTransReadCheckData            (const uint16_t data, const uint32_t node = 0);
-void            VTransReadCheckData            (const uint32_t data, const uint32_t node = 0);
-void            VTransReadCheckData            (const uint64_t data, const uint32_t node = 0);
-
-bool            VTransTryReadCheckData         (const uint8_t  data, const uint32_t node = 0);
-bool            VTransTryReadCheckData         (const uint16_t data, const uint32_t node = 0);
-bool            VTransTryReadCheckData         (const uint32_t data, const uint32_t node = 0);
-bool            VTransTryReadCheckData         (const uint64_t data, const uint32_t node = 0);
-
-// Overloaded write burst transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstWrite               (const uint32_t  addr, uint8_t *data,      const int bytesize, const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite               (const uint64_t  addr, uint8_t *data,      const int bytesize, const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite               (const uint32_t  addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite               (const uint64_t  addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteAsync          (const uint32_t  addr, uint8_t *data,      const int bytesize, const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteAsync          (const uint64_t  addr, uint8_t *data,      const int bytesize, const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrement      (const uint32_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrement      (const uint64_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrementAsync (const uint32_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrementAsync (const uint64_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandom         (const uint32_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandom         (const uint64_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandomAsync    (const uint32_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandomAsync    (const uint64_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
-
-extern void     VTransBurstPushData            (       uint8_t *data, const int count,          const uint32_t node = 0);
-extern void     VTransBurstPushIncrement       (       uint8_t *data, const int count,          const uint32_t node = 0);
-extern void     VTransBurstPushRandom          (       uint8_t *data, const int count,          const uint32_t node = 0);
-
-// Overloaded read burst transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstRead                (const uint32_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead                (const uint64_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead                (const uint32_t  addr,    const int  bytesize,   const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead                (const uint64_t  addr,    const int  bytesize,   const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadIncrement  (const uint32_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadIncrement  (const uint64_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadRandom     (const uint32_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadRandom     (const uint64_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
-
-extern void     VTransBurstPopData             (      uint8_t  *data,    const int  bytesize,   const uint32_t node = 0);
-extern void     VTransCheckBurstIncrement      (      uint8_t  *data,    const int  bytesize,   const uint32_t node = 0);
-extern void     VTransCheckBurstRandom         (      uint8_t  *data,    const int  bytesize,   const uint32_t node = 0);
-
-// Overloaded stream send transaction functions for byte, half-word, word and double-word
-extern uint8_t  VStreamSend                    (const uint8_t   data,    const int  param = 0,  const uint32_t node = 0);
-extern uint16_t VStreamSend                    (const uint16_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern uint32_t VStreamSend                    (const uint32_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern uint64_t VStreamSend                    (const uint64_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern uint8_t  VStreamSendAsync               (const uint8_t   data,    const int  param = 0,  const uint32_t node = 0);
-extern uint16_t VStreamSendAsync               (const uint16_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern uint32_t VStreamSendAsync               (const uint32_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern uint64_t VStreamSendAsync               (const uint64_t  data,    const int  param = 0,  const uint32_t node = 0);
-
-// Overloaded stream get transaction functions for byte, half-word, word and double-word
-extern void     VStreamGet                     (      uint8_t  *data,          int *status,     const uint32_t node = 0);
-extern void     VStreamGet                     (      uint16_t *data,          int *status,     const uint32_t node = 0);
-extern void     VStreamGet                     (      uint32_t *data,          int *status,     const uint32_t node = 0);
-extern void     VStreamGet                     (      uint64_t *data,          int *status,     const uint32_t node = 0);
-
-extern void     VStreamCheck                   (      uint8_t   data,    const int  param = 0,  const uint32_t node = 0);
-extern void     VStreamCheck                   (      uint16_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern void     VStreamCheck                   (      uint32_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern void     VStreamCheck                   (      uint64_t  data,    const int  param = 0,  const uint32_t node = 0);
+// Overloaded stream get common transaction functions for byte, half-word, word and double-word
+extern bool     VStreamGetCommon               (const int op, uint8_t  *rdata, int *status, const uint8_t  wdata, const int param = 0,  const uint32_t node = 0);
+extern bool     VStreamGetCommon               (const int op, uint16_t *rdata, int *status, const uint16_t wdata, const int param = 0,  const uint32_t node = 0);
+extern bool     VStreamGetCommon               (const int op, uint32_t *rdata, int *status, const uint32_t wdata, const int param = 0,  const uint32_t node = 0);
+extern bool     VStreamGetCommon               (const int op, uint64_t *rdata, int *status, const uint64_t wdata, const int param = 0,  const uint32_t node = 0);
 
 // Stream burst send and get transaction functions
-extern void     VStreamBurstSend               (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSend               (const int      bytesize, const int  param=0,    const uint32_t node = 0);
-extern void     VStreamBurstSendAsync          (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendAsync          (const int      bytesize, const int  param=0,    const uint32_t node = 0);
-extern void     VStreamBurstSendIncrement      (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendRandom         (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendIncrementAsync (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendRandomAsync    (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-
-extern void     VStreamBurstCheck              (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern void     VStreamBurstCheck              (const int      bytesize, const int  param=0,    const uint32_t node = 0);
-extern void     VStreamBurstCheckIncrement     (      uint8_t *data,     const int  bytesize,   const int      param, const uint32_t node);
-extern void     VStreamBurstCheckRandom        (      uint8_t *data,     const int  bytesize,   const int      param, const uint32_t node);
-
-extern void     VStreamBurstGet                (      uint8_t *data,     const int  bytesize,         int     *status,    const uint32_t node = 0);
-extern void     VStreamBurstGet                (const int      bytesize,       int *status,     const uint32_t node = 0);
-
-extern void     VStreamBurstPopData            (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
-extern void     VStreamBurstPushData           (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
-extern void     VStreamBurstPushCheckData      (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
-extern void     VStreamBurstPushIncrement      (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
-extern void     VStreamBurstPushCheckIncrement (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
-extern void     VStreamBurstPushRandom         (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
-extern void     VStreamBurstPushCheckRandom    (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
-
-extern bool     VStreamTryGet                  (     uint8_t  *data,           int *status,     const uint32_t node = 0);
-extern bool     VStreamTryGet                  (     uint16_t *data,           int *status,     const uint32_t node = 0);
-extern bool     VStreamTryGet                  (     uint32_t *data,           int *status,     const uint32_t node = 0);
-extern bool     VStreamTryGet                  (     uint64_t *data,           int *status,     const uint32_t node = 0);
-
-extern bool     VStreamTryCheck                (     uint8_t   data,     const int  param = 0,  const uint32_t node = 0);
-extern bool     VStreamTryCheck                (     uint16_t  data,     const int  param = 0,  const uint32_t node = 0);
-extern bool     VStreamTryCheck                (     uint32_t  data,     const int  param = 0,  const uint32_t node = 0);
-extern bool     VStreamTryCheck                (     uint64_t  data,     const int  param = 0,  const uint32_t node = 0);
-
-extern bool     VStreamBurstTryGet             (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern bool     VStreamBurstTryGet             (const int      bytesize, const int  param = 0,  const uint32_t node = 0);
-extern bool     VStreamBurstTryCheck           (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern bool     VStreamBurstTryCheck           (const int      bytesize, const int  param = 0,  const uint32_t node = 0);
-extern bool     VStreamBurstTryCheckIncrement  (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
-extern bool     VStreamBurstTryCheckRandom     (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern bool     VStreamBurstSendCommon         (const int op, const int burst_type, uint8_t* data, const int bytesize, const int param = 0, const uint32_t node = 0);
+extern bool     VStreamBurstGetCommon          (const int op, const int param,      uint8_t* data, const int bytesize, int* status,         const uint32_t node = 0);
 
 #endif
 

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -141,13 +141,13 @@ extern void      VWaitForSim                    (const uint32_t node = 0);
 extern void      VSetTestName                   (const char*    data, const int bytesize, const uint32_t node);
 
 // Overloaded transaction functions for 32 and 64 bit architecture for byte, half-word, word and double-word
-extern uint8_t   VTransUserCommon               (const int op, const uint32_t addr, const uint8_t  data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint16_t  VTransUserCommon               (const int op, const uint32_t addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint32_t  VTransUserCommon               (const int op, const uint32_t addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint8_t   VTransUserCommon               (const int op, const uint64_t addr, const uint8_t  data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint16_t  VTransUserCommon               (const int op, const uint64_t addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint32_t  VTransUserCommon               (const int op, const uint64_t addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint64_t  VTransUserCommon               (const int op, const uint64_t addr, const uint64_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint8_t   VTransUserCommon               (const int op, uint32_t *addr, const uint8_t  data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint16_t  VTransUserCommon               (const int op, uint32_t *addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint32_t  VTransUserCommon               (const int op, uint32_t *addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint8_t   VTransUserCommon               (const int op, uint64_t *addr, const uint8_t  data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint16_t  VTransUserCommon               (const int op, uint64_t *addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint32_t  VTransUserCommon               (const int op, uint64_t *addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint64_t  VTransUserCommon               (const int op, uint64_t *addr, const uint64_t data, int* status, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded stream transaction functions for 32 and 64 bit architecture
 extern void      VTransBurstCommon              (const int op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -15,7 +15,7 @@
 //
 //  Revision History:
 //    Date      Version    Description
-//    05/2023   2023.05    Adding asynchronous transaction support
+//    05/2023   2023.05    Adding Async, Try and Check transaction support
 //    03/2023   2023.04    Adding basic stream support
 //    01/2023   2023.01    Initial revision
 //
@@ -129,52 +129,52 @@ typedef void (*pVUserMain_t)(void);
 // -------------------------------------------------------------------------
 
 // VUser function prototypes
-#ifdef __cplusplus
+# ifdef __cplusplus
 
 // Function to advance simulation by a number of clock ticks
-extern int      VTick                          (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
+extern int       VTick                          (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
 
 // GHDL main support function to wait for simultion to be ready to call
-extern void     VWaitForSim                    (const uint32_t node = 0);
+extern void      VWaitForSim                    (const uint32_t node = 0);
 
 // OSVVM support function to set the test name
-extern void     VSetTestName                   (const char*    data, const int bytesize, const uint32_t node);
+extern void      VSetTestName                   (const char*    data, const int bytesize, const uint32_t node);
 
 // Overloaded transaction functions for 32 and 64 bit architecture for byte, half-word, word and double-word
-extern uint8_t  VTransCommon                   (const int op, const uint32_t addr, const uint8_t data,  int* status, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransCommon                   (const int op, const uint32_t addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransCommon                   (const int op, const uint32_t addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint8_t  VTransCommon                   (const int op, const uint64_t addr, const uint8_t  data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransCommon                   (const int op, const uint64_t addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransCommon                   (const int op, const uint64_t addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
-extern uint64_t VTransCommon                   (const int op, const uint64_t addr, const uint64_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint8_t   VTransUserCommon               (const int op, const uint32_t addr, const uint8_t  data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint16_t  VTransUserCommon               (const int op, const uint32_t addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint32_t  VTransUserCommon               (const int op, const uint32_t addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint8_t   VTransUserCommon               (const int op, const uint64_t addr, const uint8_t  data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint16_t  VTransUserCommon               (const int op, const uint64_t addr, const uint16_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint32_t  VTransUserCommon               (const int op, const uint64_t addr, const uint32_t data, int* status, const int prot = 0, const uint32_t node = 0);
+extern uint64_t  VTransUserCommon               (const int op, const uint64_t addr, const uint64_t data, int* status, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded stream transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstCommon              (const int op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstCommon              (const int op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void      VTransBurstCommon              (const int op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void      VTransBurstCommon              (const int op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded stream send/check common transaction functions for byte, half-word, word and double-word
-extern uint8_t  VStreamCommon                  (const int op, const uint8_t   data,    const int  param = 0,  const uint32_t node = 0);
-extern uint16_t VStreamCommon                  (const int op, const uint16_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern uint32_t VStreamCommon                  (const int op, const uint32_t  data,    const int  param = 0,  const uint32_t node = 0);
-extern uint64_t VStreamCommon                  (const int op, const uint64_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern uint8_t   VStreamUserCommon              (const int op, const uint8_t   data, const int  param = 0,  const uint32_t node = 0);
+extern uint16_t  VStreamUserCommon              (const int op, const uint16_t  data, const int  param = 0,  const uint32_t node = 0);
+extern uint32_t  VStreamUserCommon              (const int op, const uint32_t  data, const int  param = 0,  const uint32_t node = 0);
+extern uint64_t  VStreamUserCommon              (const int op, const uint64_t  data, const int  param = 0,  const uint32_t node = 0);
 
 // Overloaded stream get common transaction functions for byte, half-word, word and double-word
-extern bool     VStreamGetCommon               (const int op, uint8_t  *rdata, int *status, const uint8_t  wdata, const int param = 0,  const uint32_t node = 0);
-extern bool     VStreamGetCommon               (const int op, uint16_t *rdata, int *status, const uint16_t wdata, const int param = 0,  const uint32_t node = 0);
-extern bool     VStreamGetCommon               (const int op, uint32_t *rdata, int *status, const uint32_t wdata, const int param = 0,  const uint32_t node = 0);
-extern bool     VStreamGetCommon               (const int op, uint64_t *rdata, int *status, const uint64_t wdata, const int param = 0,  const uint32_t node = 0);
+extern bool      VStreamUserGetCommon           (const int op, uint8_t  *rdata, int *status, const uint8_t  wdata, const int param = 0,  const uint32_t node = 0);
+extern bool      VStreamUserGetCommon           (const int op, uint16_t *rdata, int *status, const uint16_t wdata, const int param = 0,  const uint32_t node = 0);
+extern bool      VStreamUserGetCommon           (const int op, uint32_t *rdata, int *status, const uint32_t wdata, const int param = 0,  const uint32_t node = 0);
+extern bool      VStreamUserGetCommon           (const int op, uint64_t *rdata, int *status, const uint64_t wdata, const int param = 0,  const uint32_t node = 0);
 
-// Stream burst send and get transaction functions
-extern bool     VStreamBurstSendCommon         (const int op, const int burst_type, uint8_t* data, const int bytesize, const int param = 0, const uint32_t node = 0);
-extern bool     VStreamBurstGetCommon          (const int op, const int param,      uint8_t* data, const int bytesize, int* status,         const uint32_t node = 0);
+// Stream burst send and get common transaction functions
+extern bool      VStreamUserBurstSendCommon     (const int op, const int burst_type, uint8_t* data, const int bytesize, const int param = 0, const uint32_t node = 0);
+extern bool      VStreamUserBurstGetCommon      (const int op, const int param,      uint8_t* data, const int bytesize, int* status,         const uint32_t node = 0);
 
-#endif
+# endif
 
 // User function called from VInit to instigate new user thread
-extern EXTC int  VUser           (const int node);
+extern EXTC int  VUser                          (const int node);
 
 // User interrupt callback registering function
-extern EXTC void VRegInterrupt   (const pVUserInt_t func, const uint32_t node);
+extern EXTC void VRegInterrupt                  (const pVUserInt_t func, const uint32_t node);
 
 #endif

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -132,185 +132,206 @@ typedef void (*pVUserMain_t)(void);
 #ifdef __cplusplus
 
 // Function to advance simulation by a number of clock ticks
-extern int      VTick                     (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
+extern int      VTick                          (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
 
 // GHDL main support function to wait for simultion to be ready to call
-extern void     VWaitForSim               (const uint32_t node = 0);
+extern void     VWaitForSim                    (const uint32_t node = 0);
 
 // OSVVM support function to set the test name
-extern void     VSetTestName              (const char* data, const int bytesize, const uint32_t node);
+extern void     VSetTestName                   (const char*    data, const int bytesize, const uint32_t node);
 
 // Overloaded write transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word and double-word
-extern uint8_t  VTransWrite               (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWrite               (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWrite               (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint8_t  VTransWrite               (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWrite               (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWrite               (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint64_t VTransWrite               (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWrite                    (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWrite                    (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWrite                    (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWrite                    (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWrite                    (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWrite                    (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint64_t VTransWrite                    (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded write asynchronous transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word and double-word
-extern uint8_t  VTransWriteAsync          (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWriteAsync          (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWriteAsync          (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint8_t  VTransWriteAsync          (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWriteAsync          (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWriteAsync          (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint64_t VTransWriteAsync          (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWriteAsync               (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWriteAsync               (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWriteAsync               (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWriteAsync               (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWriteAsync               (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWriteAsync               (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint64_t VTransWriteAsync               (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded read transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word, and double-word
-extern void     VTransRead                (const uint32_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                (const uint32_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                (const uint32_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                (const uint64_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                (const uint64_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                (const uint64_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead                (const uint64_t addr,       uint64_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                     (const uint32_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                     (const uint32_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                     (const uint32_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                     (const uint64_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                     (const uint64_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                     (const uint64_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                     (const uint64_t addr,       uint64_t *data, const int prot = 0, const uint32_t node = 0);
 
-extern void     VTransReadCheck           (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck           (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck           (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck           (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck           (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck           (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransReadCheck           (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck                (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck                (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck                (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck                (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck                (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck                (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck                (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded write-read transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word and double-word
-uint8_t         VTransWriteAndRead        (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndRead        (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndRead        (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint8_t         VTransWriteAndRead        (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndRead        (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndRead        (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint64_t        VTransWriteAndRead        (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndRead             (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndRead             (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndRead             (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndRead             (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndRead             (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndRead             (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint64_t        VTransWriteAndRead             (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded write-read asynchronous transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word and double-word
-uint8_t         VTransWriteAndReadAsync   (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndReadAsync   (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndReadAsync   (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint8_t         VTransWriteAndReadAsync   (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndReadAsync   (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndReadAsync   (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint64_t        VTransWriteAndReadAsync   (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndReadAsync        (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndReadAsync        (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndReadAsync        (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndReadAsync        (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndReadAsync        (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndReadAsync        (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint64_t        VTransWriteAndReadAsync        (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded write address asynchronous transaction functions for 32 and 64 bit architecture
-void            VTransWriteAddressAsync   (const uint32_t addr, const uint32_t node = 0);
-void            VTransWriteAddressAsync   (const uint64_t addr, const uint32_t node = 0);
+void            VTransWriteAddressAsync        (const uint32_t addr, const uint32_t node = 0);
+void            VTransWriteAddressAsync        (const uint64_t addr, const uint32_t node = 0);
 
 // Overloaded write data transaction functions for byte, half-word, word and double-word
-void            VTransWriteDataAsync      (const uint8_t  data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync      (const uint16_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync      (const uint32_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync      (const uint64_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync           (const uint8_t  data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync           (const uint16_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync           (const uint32_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync           (const uint64_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
 
-// Overloaded read address asynchronous transaction functions for 32 and 64 bit architecture
-void            VTransReadAddressAsync    (const uint32_t addr, const uint32_t node = 0);
-void            VTransReadAddressAsync    (const uint64_t addr, const uint32_t node = 0);
-
-// Overloaded write data transaction functions for byte, half-word, word and double-word
-void            VTransReadData            (uint8_t       *data, const uint32_t node = 0);
-void            VTransReadData            (uint16_t      *data, const uint32_t node = 0);
-void            VTransReadData            (uint32_t      *data, const uint32_t node = 0);
-void            VTransReadData            (uint64_t      *data, const uint32_t node = 0);
-
-bool            VTransTryReadData         (uint8_t       *data, const uint32_t node = 0);
-bool            VTransTryReadData         (uint16_t      *data, const uint32_t node = 0);
-bool            VTransTryReadData         (uint32_t      *data, const uint32_t node = 0);
-bool            VTransTryReadData         (uint64_t      *data, const uint32_t node = 0);
+// Overloaded read address asynchronous tr     ansaction functions for 32 and 64 bit architecture
+void            VTransReadAddressAsync         (const uint32_t addr, const uint32_t node = 0);
+void            VTransReadAddressAsync         (const uint64_t addr, const uint32_t node = 0);
 
 // Overloaded write data transaction functions for byte, half-word, word and double-word
-void            VTransReadCheckData       (uint8_t        data, const uint32_t node = 0);
-void            VTransReadCheckData       (uint16_t       data, const uint32_t node = 0);
-void            VTransReadCheckData       (uint32_t       data, const uint32_t node = 0);
-void            VTransReadCheckData       (uint64_t       data, const uint32_t node = 0);
+void            VTransReadData                 (     uint8_t  *data, const uint32_t node = 0);
+void            VTransReadData                 (     uint16_t *data, const uint32_t node = 0);
+void            VTransReadData                 (     uint32_t *data, const uint32_t node = 0);
+void            VTransReadData                 (     uint64_t *data, const uint32_t node = 0);
 
-bool            VTransTryReadCheckData    (uint8_t        data, const uint32_t node = 0);
-bool            VTransTryReadCheckData    (uint16_t       data, const uint32_t node = 0);
-bool            VTransTryReadCheckData    (uint32_t       data, const uint32_t node = 0);
-bool            VTransTryReadCheckData    (uint64_t       data, const uint32_t node = 0);
+bool            VTransTryReadData              (     uint8_t  *data, const uint32_t node = 0);
+bool            VTransTryReadData              (     uint16_t *data, const uint32_t node = 0);
+bool            VTransTryReadData              (     uint32_t *data, const uint32_t node = 0);
+bool            VTransTryReadData              (     uint64_t *data, const uint32_t node = 0);
+
+// Overloaded write data transaction functions for byte, half-word, word and double-word
+void            VTransReadCheckData            (const uint8_t  data, const uint32_t node = 0);
+void            VTransReadCheckData            (const uint16_t data, const uint32_t node = 0);
+void            VTransReadCheckData            (const uint32_t data, const uint32_t node = 0);
+void            VTransReadCheckData            (const uint64_t data, const uint32_t node = 0);
+
+bool            VTransTryReadCheckData         (const uint8_t  data, const uint32_t node = 0);
+bool            VTransTryReadCheckData         (const uint16_t data, const uint32_t node = 0);
+bool            VTransTryReadCheckData         (const uint32_t data, const uint32_t node = 0);
+bool            VTransTryReadCheckData         (const uint64_t data, const uint32_t node = 0);
 
 // Overloaded write burst transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstWrite               (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite               (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite               (const uint32_t addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite               (const uint64_t addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteAsync          (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteAsync          (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrement      (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrement      (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrementAsync (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrementAsync (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandom         (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandom         (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandomAsync    (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandomAsync    (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite               (const uint32_t  addr, uint8_t *data,      const int bytesize, const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite               (const uint64_t  addr, uint8_t *data,      const int bytesize, const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite               (const uint32_t  addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite               (const uint64_t  addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteAsync          (const uint32_t  addr, uint8_t *data,      const int bytesize, const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteAsync          (const uint64_t  addr, uint8_t *data,      const int bytesize, const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrement      (const uint32_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrement      (const uint64_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrementAsync (const uint32_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrementAsync (const uint64_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandom         (const uint32_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandom         (const uint64_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandomAsync    (const uint32_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandomAsync    (const uint64_t  addr, uint8_t *data,      const int count,    const int      prot = 0, const uint32_t node = 0);
 
-extern void     VTransBurstPushData            (uint8_t *data, const int count, const uint32_t node = 0);
-extern void     VTransBurstPushIncrement       (uint8_t *data, const int count, const uint32_t node = 0);
-extern void     VTransBurstPushRandom          (uint8_t *data, const int count, const uint32_t node = 0);
+extern void     VTransBurstPushData            (       uint8_t *data, const int count,          const uint32_t node = 0);
+extern void     VTransBurstPushIncrement       (       uint8_t *data, const int count,          const uint32_t node = 0);
+extern void     VTransBurstPushRandom          (       uint8_t *data, const int count,          const uint32_t node = 0);
 
 // Overloaded read burst transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstRead                (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead                (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadIncrement  (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadIncrement  (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadRandom     (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadRandom     (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead                (const uint32_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead                (const uint64_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead                (const uint32_t  addr,    const int  bytesize,   const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead                (const uint64_t  addr,    const int  bytesize,   const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadIncrement  (const uint32_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadIncrement  (const uint64_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadRandom     (const uint32_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadRandom     (const uint64_t  addr,    uint8_t   *data,       const int bytesize, const int prot = 0, const uint32_t node = 0);
 
-extern void     VTransBurstPopData             (uint8_t *data, const int bytesize, const uint32_t node = 0);
-extern void     VTransCheckBurstIncrement      (uint8_t *data, const int bytesize, const uint32_t node = 0);
-extern void     VTransCheckBurstRandom         (uint8_t *data, const int bytesize, const uint32_t node = 0);
+extern void     VTransBurstPopData             (      uint8_t  *data,    const int  bytesize,   const uint32_t node = 0);
+extern void     VTransCheckBurstIncrement      (      uint8_t  *data,    const int  bytesize,   const uint32_t node = 0);
+extern void     VTransCheckBurstRandom         (      uint8_t  *data,    const int  bytesize,   const uint32_t node = 0);
 
 // Overloaded stream send transaction functions for byte, half-word, word and double-word
-extern uint8_t  VStreamSend                    (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
-extern uint16_t VStreamSend                    (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint32_t VStreamSend                    (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint64_t VStreamSend                    (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint8_t  VStreamSendAsync               (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
-extern uint16_t VStreamSendAsync               (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint32_t VStreamSendAsync               (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint64_t VStreamSendAsync               (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint8_t  VStreamSend                    (const uint8_t   data,    const int  param = 0,  const uint32_t node = 0);
+extern uint16_t VStreamSend                    (const uint16_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern uint32_t VStreamSend                    (const uint32_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern uint64_t VStreamSend                    (const uint64_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern uint8_t  VStreamSendAsync               (const uint8_t   data,    const int  param = 0,  const uint32_t node = 0);
+extern uint16_t VStreamSendAsync               (const uint16_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern uint32_t VStreamSendAsync               (const uint32_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern uint64_t VStreamSendAsync               (const uint64_t  data,    const int  param = 0,  const uint32_t node = 0);
 
 // Overloaded stream get transaction functions for byte, half-word, word and double-word
-extern void     VStreamGet                     (      uint8_t  *data,       int *status,    const uint32_t node = 0);
-extern void     VStreamGet                     (      uint16_t *data,       int *status,    const uint32_t node = 0);
-extern void     VStreamGet                     (      uint32_t *data,       int *status,    const uint32_t node = 0);
-extern void     VStreamGet                     (      uint64_t *data,       int *status,    const uint32_t node = 0);
+extern void     VStreamGet                     (      uint8_t  *data,          int *status,     const uint32_t node = 0);
+extern void     VStreamGet                     (      uint16_t *data,          int *status,     const uint32_t node = 0);
+extern void     VStreamGet                     (      uint32_t *data,          int *status,     const uint32_t node = 0);
+extern void     VStreamGet                     (      uint64_t *data,          int *status,     const uint32_t node = 0);
 
-extern void     VStreamCheck                   (      uint8_t   data, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamCheck                   (      uint16_t  data, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamCheck                   (      uint32_t  data, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamCheck                   (      uint64_t  data, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamCheck                   (      uint8_t   data,    const int  param = 0,  const uint32_t node = 0);
+extern void     VStreamCheck                   (      uint16_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern void     VStreamCheck                   (      uint32_t  data,    const int  param = 0,  const uint32_t node = 0);
+extern void     VStreamCheck                   (      uint64_t  data,    const int  param = 0,  const uint32_t node = 0);
 
 // Stream burst send and get transaction functions
-extern void     VStreamBurstSend               (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSend               (const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendAsync          (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendAsync          (const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstCheck              (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstCheck              (const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstCheckIncrement     (      uint8_t  *data, const int  bytesize, const int  param, const uint32_t node);
-extern void     VStreamBurstCheckRandom        (      uint8_t  *data, const int  bytesize, const int  param, const uint32_t node);
-extern void     VStreamBurstSendIncrement      (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendRandom         (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendIncrementAsync (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstSendRandomAsync    (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
-extern void     VStreamBurstGet                (      uint8_t  *data, const int  bytesize,       int* status,    const uint32_t node = 0);
-extern void     VStreamBurstGet                (const int      bytesize, int*    status,   const uint32_t node = 0);
-extern void     VStreamBurstPopData            (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
-extern void     VStreamBurstPushData           (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
-extern void     VStreamBurstPushCheckData      (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
-extern void     VStreamBurstPushIncrement      (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
-extern void     VStreamBurstPushCheckIncrement (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
-extern void     VStreamBurstPushRandom         (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
-extern void     VStreamBurstPushCheckRandom    (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstSend               (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSend               (const int      bytesize, const int  param=0,    const uint32_t node = 0);
+extern void     VStreamBurstSendAsync          (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendAsync          (const int      bytesize, const int  param=0,    const uint32_t node = 0);
+extern void     VStreamBurstSendIncrement      (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendRandom         (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendIncrementAsync (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendRandomAsync    (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+
+extern void     VStreamBurstCheck              (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern void     VStreamBurstCheck              (const int      bytesize, const int  param=0,    const uint32_t node = 0);
+extern void     VStreamBurstCheckIncrement     (      uint8_t *data,     const int  bytesize,   const int      param, const uint32_t node);
+extern void     VStreamBurstCheckRandom        (      uint8_t *data,     const int  bytesize,   const int      param, const uint32_t node);
+
+extern void     VStreamBurstGet                (      uint8_t *data,     const int  bytesize,         int     *status,    const uint32_t node = 0);
+extern void     VStreamBurstGet                (const int      bytesize,       int *status,     const uint32_t node = 0);
+
+extern void     VStreamBurstPopData            (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
+extern void     VStreamBurstPushData           (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
+extern void     VStreamBurstPushCheckData      (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
+extern void     VStreamBurstPushIncrement      (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
+extern void     VStreamBurstPushCheckIncrement (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
+extern void     VStreamBurstPushRandom         (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
+extern void     VStreamBurstPushCheckRandom    (      uint8_t* data,     const int  bytesize,   const uint32_t node = 0);
+
+extern bool     VStreamTryGet                  (     uint8_t  *data,           int *status,     const uint32_t node = 0);
+extern bool     VStreamTryGet                  (     uint16_t *data,           int *status,     const uint32_t node = 0);
+extern bool     VStreamTryGet                  (     uint32_t *data,           int *status,     const uint32_t node = 0);
+extern bool     VStreamTryGet                  (     uint64_t *data,           int *status,     const uint32_t node = 0);
+
+extern bool     VStreamTryCheck                (     uint8_t   data,     const int  param = 0,  const uint32_t node = 0);
+extern bool     VStreamTryCheck                (     uint16_t  data,     const int  param = 0,  const uint32_t node = 0);
+extern bool     VStreamTryCheck                (     uint32_t  data,     const int  param = 0,  const uint32_t node = 0);
+extern bool     VStreamTryCheck                (     uint64_t  data,     const int  param = 0,  const uint32_t node = 0);
+
+extern bool     VStreamBurstTryGet             (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern bool     VStreamBurstTryGet             (const int      bytesize, const int  param = 0,  const uint32_t node = 0);
+extern bool     VStreamBurstTryCheck           (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern bool     VStreamBurstTryCheck           (const int      bytesize, const int  param = 0,  const uint32_t node = 0);
+extern bool     VStreamBurstTryCheckIncrement  (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+extern bool     VStreamBurstTryCheckRandom     (      uint8_t *data,     const int  bytesize,   const int      param = 0, const uint32_t node = 0);
+
 #endif
 
 // User function called from VInit to instigate new user thread

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -235,26 +235,32 @@ bool            VTransTryReadCheckData    (uint32_t       data, const uint32_t n
 bool            VTransTryReadCheckData    (uint64_t       data, const uint32_t node = 0);
 
 // Overloaded write burst transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstWrite          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteAsync     (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteAsync     (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrement      (const uint32_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrement      (const uint64_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrementAsync (const uint32_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteIncrementAsync (const uint64_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandom         (const uint32_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandom         (const uint64_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandomAsync    (const uint32_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteRandomAsync    (const uint64_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite               (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite               (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteAsync          (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteAsync          (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrement      (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrement      (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrementAsync (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrementAsync (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandom         (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandom         (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandomAsync    (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandomAsync    (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
+
+extern void     VTransBurstPushIncrement       (uint8_t *data, const int count, const uint32_t node = 0);
+extern void     VTransBurstPushRandom          (uint8_t *data, const int count, const uint32_t node = 0);
 
 // Overloaded read burst transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstRead           (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead           (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadIncrement (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadIncrement (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadRandom    (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransCheckBurstReadRandom    (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead                (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead                (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadIncrement  (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadIncrement  (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadRandom     (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadRandom     (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+
+extern void     VTransCheckBurstIncrement      (uint8_t *data, const int bytesize, const uint32_t node = 0);
+extern void     VTransCheckBurstRandom         (uint8_t *data, const int bytesize, const uint32_t node = 0);
 
 // Overloaded stream send transaction functions for byte, half-word, word and double-word
 extern uint8_t  VStreamSend               (const uint8_t   data, const int  param = 0, const uint32_t node = 0);

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -1,7 +1,7 @@
 // =========================================================================
 //
-//  File Name:         OsvvmVUser.cpp
-//  Design Unit Name:  
+//  File Name:         OsvvmVUser.h
+//  Design Unit Name:
 //  Revision:          OSVVM MODELS STANDARD VERSION
 //
 //  Maintainer:        Simon Southwell email:  simon.southwell@gmail.com
@@ -15,12 +15,14 @@
 //
 //  Revision History:
 //    Date      Version    Description
-//    10/2022   2023.01    Initial revision
+//    05/2023   2023.05    Adding asynchronous transaction support
+//    03/2023   2023.04    Adding basic stream support
+//    01/2023   2023.01    Initial revision
 //
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -39,6 +41,10 @@
 #ifndef _OSVVM_VUSER_H_
 #define _OSVVM_VUSER_H_
 
+// -------------------------------------------------------------------------
+// INCLUDES
+// -------------------------------------------------------------------------
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -55,6 +61,9 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+// -------------------------------------------------------------------------
+// DEFINES AND MACROS
+// -------------------------------------------------------------------------
 
 #define DELTA_CYCLE             -1
 #define NO_DELTA_CYCLE          0
@@ -65,65 +74,12 @@ extern "C"
 #else
 #define SLEEPFOREVER            { while(1) VTick(GO_TO_SLEEP, node); }
 #endif
-                                
+
 #define MAX_INT_LEVEL           256
 #define MIN_INT_LEVEL           1
 
 #define HUNDRED_MILLISECS       1000000
 #define FIVESEC_TIMEOUT         (50*HUNDRED_MILLISECS)
-
-// Pointer to pthread_create compatible function
-typedef void *(*pThreadFunc_t)(void *);
-
-// VUser function prototypes
-#ifdef __cplusplus
-// VProc write and read functions (fixed at 32-bit)
-extern int      VTick            (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
-extern void     VWaitForSim      (const uint32_t node = 0);
-extern void     VSetTestName     (const char* data, const int bytesize, const uint32_t node);
-
-// Overloaded write and read transaction functions for 32 bit architecture for byte,
-// half-word and, words
-extern uint8_t  VTransWrite      (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead       (const uint32_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWrite      (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead       (const uint32_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWrite      (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead       (const uint32_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
-
-// Overloaded write and read transaction functions for 64 bit architecture for byte,
-// half-word, word, and double-word
-extern uint8_t  VTransWrite      (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead       (const uint64_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWrite      (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead       (const uint64_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWrite      (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead       (const uint64_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
-extern uint64_t VTransWrite      (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead       (const uint64_t addr,       uint64_t *data, const int prot = 0, const uint32_t node = 0);
-
-extern void     VTransBurstWrite (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead  (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead  (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-
-extern uint8_t  VStreamSend      (const uint8_t   data, const int param, const uint32_t node = 0);
-extern uint8_t  VStreamSend      (const uint16_t  data, const int param, const uint32_t node = 0);
-extern uint8_t  VStreamSend      (const uint32_t  data, const int param, const uint32_t node = 0);
-extern uint8_t  VStreamSend      (const uint64_t  data, const int param, const uint32_t node = 0);
-
-extern void     VStreamGet       (      uint8_t  *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet       (      uint16_t *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet       (      uint32_t *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet       (      uint64_t *data,       int *stream, const uint32_t node = 0);
-
-extern void     VStreamBurstSend (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
-extern void     VStreamBurstGet  (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
-
-#endif
-
-extern EXTC int  VUser           (const int node);
-extern EXTC void VRegInterrupt   (const pVUserInt_t func, const uint32_t node);
 
 // In windows using the FLI, a \n in the printf format string causes
 // two lines to be advanced, so replace new lines with carriage returns
@@ -158,8 +114,142 @@ extern EXTC void VRegInterrupt   (const pVUserInt_t func, const uint32_t node);
 #define DebugVPrint(...) {}
 
 #endif
+// -------------------------------------------------------------------------
+// TYPE DEFINITIONS
+// -------------------------------------------------------------------------
+
+// Pointer to pthread_create compatible function
+typedef void *(*pThreadFunc_t)(void *);
 
 // Pointer to VUserMain function type definition
 typedef void (*pVUserMain_t)(void);
+
+// -------------------------------------------------------------------------
+// FUNCTION PROTOTYPES
+// -------------------------------------------------------------------------
+
+// VUser function prototypes
+#ifdef __cplusplus
+
+// Function to advance simulation by a number of clock ticks
+extern int      VTick                   (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
+
+// GHDL main support function to wait for simultion to be ready to call
+extern void     VWaitForSim             (const uint32_t node = 0);
+
+// OSVVM support function to set the test name
+extern void     VSetTestName            (const char* data, const int bytesize, const uint32_t node);
+
+// Overloaded write transaction functions for 32 and 64 bit architecture for byte,
+// half-word, word and double-word
+extern uint8_t  VTransWrite             (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWrite             (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWrite             (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWrite             (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWrite             (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWrite             (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint64_t VTransWrite             (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+
+// Overloaded write asynchronous transaction functions for 32 and 64 bit architecture for byte,
+// half-word, word and double-word
+extern uint8_t  VTransWriteAsync        (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWriteAsync        (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWriteAsync        (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWriteAsync        (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWriteAsync        (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWriteAsync        (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint64_t VTransWriteAsync        (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+
+// Overloaded read transaction functions for 32 and 64 bit architecture for byte,
+// half-word, word, and double-word
+extern void     VTransRead              (const uint32_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead              (const uint32_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead              (const uint32_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead              (const uint64_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead              (const uint64_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead              (const uint64_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead              (const uint64_t addr,       uint64_t *data, const int prot = 0, const uint32_t node = 0);
+
+// Overloaded write-read transaction functions for 32 and 64 bit architecture for byte,
+// half-word, word and double-word
+uint8_t         VTransWriteAndRead      (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndRead      (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndRead      (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndRead      (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndRead      (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndRead      (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint64_t        VTransWriteAndRead      (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+
+// Overloaded write-read asynchronous transaction functions for 32 and 64 bit architecture for byte,
+// half-word, word and double-word
+uint8_t         VTransWriteAndReadAsync (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndReadAsync (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndReadAsync (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndReadAsync (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndReadAsync (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndReadAsync (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint64_t        VTransWriteAndReadAsync (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+
+// Overloaded write address asynchronous transaction functions for 32 and 64 bit architecture 
+void            VTransWriteAddressAsync (const uint32_t addr, const uint32_t node = 0);
+void            VTransWriteAddressAsync (const uint64_t addr, const uint32_t node = 0);
+
+// Overloaded write data transaction functions for byte, half-word, word and double-word
+void            VTransWriteDataAsync    (const uint8_t  data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync    (const uint16_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync    (const uint32_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync    (const uint64_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+
+// Overloaded read address asynchronous transaction functions for 32 and 64 bit architecture
+void            VTransReadAddressAsync  (const uint32_t addr, const uint32_t node = 0);
+void            VTransReadAddressAsync  (const uint64_t addr, const uint32_t node = 0);
+
+// Overloaded write data transaction functions for byte, half-word, word and double-word
+void            VTransReadData          (uint8_t       *data, const uint32_t node = 0);
+void            VTransReadData          (uint16_t      *data, const uint32_t node = 0);
+void            VTransReadData          (uint32_t      *data, const uint32_t node = 0);
+void            VTransReadData          (uint64_t      *data, const uint32_t node = 0);
+
+// Overloaded write burst transaction functions for 32 and 64 bit architecture
+extern void     VTransBurstWrite        (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite        (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+
+// Overloaded write burst asynchronous transaction functions for 32 and 64 bit architecture
+extern void     VTransBurstWriteAsync   (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteAsync   (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+
+// Overloaded read burst transaction functions for 32 and 64 bit architecture
+extern void     VTransBurstRead         (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead         (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+
+// Overloaded stream send transaction functions for byte, half-word, word and double-word
+extern uint8_t  VStreamSend             (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
+extern uint16_t VStreamSend             (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint32_t VStreamSend             (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint64_t VStreamSend             (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
+
+extern uint8_t  VStreamSendAsync        (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
+extern uint16_t VStreamSendAsync        (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint32_t VStreamSendAsync        (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint64_t VStreamSendAsync        (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
+
+// Overloaded stream get transaction functions for byte, half-word, word and double-word
+extern void     VStreamGet              (      uint8_t  *data,       int *stream, const uint32_t node = 0);
+extern void     VStreamGet              (      uint16_t *data,       int *stream, const uint32_t node = 0);
+extern void     VStreamGet              (      uint32_t *data,       int *stream, const uint32_t node = 0);
+extern void     VStreamGet              (      uint64_t *data,       int *stream, const uint32_t node = 0);
+
+// Stream burst send and get transaction functions 
+extern void     VStreamBurstSend        (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
+extern void     VStreamBurstSendAsync   (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
+extern void     VStreamBurstGet         (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
+
+#endif
+
+// User function called from VInit to instigate new user thread
+extern EXTC int  VUser           (const int node);
+
+// User interrupt callback registering function
+extern EXTC void VRegInterrupt   (const pVUserInt_t func, const uint32_t node);
 
 #endif

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -291,13 +291,26 @@ extern void     VStreamCheck                   (      uint64_t  data, const int 
 
 // Stream burst send and get transaction functions
 extern void     VStreamBurstSend               (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSend               (const int  bytesize, const int  param = 0, const uint32_t node = 0);
 extern void     VStreamBurstSendAsync          (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendAsync          (const int  bytesize, const int  param = 0, const uint32_t node = 0);
 extern void     VStreamBurstCheck              (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstCheck              (const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstCheckIncrement     (      uint8_t  *data, const int  bytesize, const int  param, const uint32_t node);
+extern void     VStreamBurstCheckRandom        (      uint8_t  *data, const int  bytesize, const int  param, const uint32_t node);
 extern void     VStreamBurstSendIncrement      (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
 extern void     VStreamBurstSendRandom         (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendIncrementAsync (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendRandomAsync    (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
 extern void     VStreamBurstGet                (      uint8_t  *data, const int  bytesize,       int* status,    const uint32_t node = 0);
 extern void     VStreamBurstGet                (const int      bytesize, int*    status,   const uint32_t node = 0);
 extern void     VStreamBurstPopData            (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstPushData           (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstPushCheckData      (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstPushIncrement      (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstPushCheckIncrement (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstPushRandom         (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstPushCheckRandom    (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
 #endif
 
 // User function called from VInit to instigate new user thread

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -279,16 +279,25 @@ extern uint32_t VStreamSendAsync               (const uint32_t  data, const int 
 extern uint64_t VStreamSendAsync               (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
 
 // Overloaded stream get transaction functions for byte, half-word, word and double-word
-extern void     VStreamGet                     (      uint8_t  *data,       int *stream,   const uint32_t node = 0);
-extern void     VStreamGet                     (      uint16_t *data,       int *stream,   const uint32_t node = 0);
-extern void     VStreamGet                     (      uint32_t *data,       int *stream,   const uint32_t node = 0);
-extern void     VStreamGet                     (      uint64_t *data,       int *stream,   const uint32_t node = 0);
+extern void     VStreamGet                     (      uint8_t  *data,       int *status,    const uint32_t node = 0);
+extern void     VStreamGet                     (      uint16_t *data,       int *status,    const uint32_t node = 0);
+extern void     VStreamGet                     (      uint32_t *data,       int *status,    const uint32_t node = 0);
+extern void     VStreamGet                     (      uint64_t *data,       int *status,    const uint32_t node = 0);
+
+extern void     VStreamCheck                   (      uint8_t   data, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamCheck                   (      uint16_t  data, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamCheck                   (      uint32_t  data, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamCheck                   (      uint64_t  data, const int  param = 0, const uint32_t node = 0);
 
 // Stream burst send and get transaction functions
-extern void     VStreamBurstSend               (      uint8_t  *data, const int  bytesize, const uint32_t node = 0);
-extern void     VStreamBurstSendAsync          (      uint8_t  *data, const int  bytesize, const uint32_t node = 0);
-extern void     VStreamBurstGet                (      uint8_t  *data, const int  bytesize, const uint32_t node = 0);
-
+extern void     VStreamBurstSend               (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendAsync          (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstCheck              (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendIncrement      (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstSendRandom         (      uint8_t  *data, const int  bytesize, const int  param = 0, const uint32_t node = 0);
+extern void     VStreamBurstGet                (      uint8_t  *data, const int  bytesize,       int* status,    const uint32_t node = 0);
+extern void     VStreamBurstGet                (const int      bytesize, int*    status,   const uint32_t node = 0);
+extern void     VStreamBurstPopData            (      uint8_t* data,  const int  bytesize, const uint32_t node = 0);
 #endif
 
 // User function called from VInit to instigate new user thread

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -237,6 +237,8 @@ bool            VTransTryReadCheckData    (uint64_t       data, const uint32_t n
 // Overloaded write burst transaction functions for 32 and 64 bit architecture
 extern void     VTransBurstWrite               (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransBurstWrite               (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite               (const uint32_t addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite               (const uint64_t addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransBurstWriteAsync          (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransBurstWriteAsync          (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransBurstWriteIncrement      (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
@@ -248,40 +250,44 @@ extern void     VTransBurstWriteRandom         (const uint64_t addr, uint8_t *da
 extern void     VTransBurstWriteRandomAsync    (const uint32_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
 extern void     VTransBurstWriteRandomAsync    (const uint64_t addr, uint8_t *data, const int count,    const int prot = 0, const uint32_t node = 0);
 
+extern void     VTransBurstPushData            (uint8_t *data, const int count, const uint32_t node = 0);
 extern void     VTransBurstPushIncrement       (uint8_t *data, const int count, const uint32_t node = 0);
 extern void     VTransBurstPushRandom          (uint8_t *data, const int count, const uint32_t node = 0);
 
 // Overloaded read burst transaction functions for 32 and 64 bit architecture
 extern void     VTransBurstRead                (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransBurstRead                (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead                (const uint32_t addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead                (const uint64_t addr, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransCheckBurstReadIncrement  (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransCheckBurstReadIncrement  (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransCheckBurstReadRandom     (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void     VTransCheckBurstReadRandom     (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 
+extern void     VTransBurstPopData             (uint8_t *data, const int bytesize, const uint32_t node = 0);
 extern void     VTransCheckBurstIncrement      (uint8_t *data, const int bytesize, const uint32_t node = 0);
 extern void     VTransCheckBurstRandom         (uint8_t *data, const int bytesize, const uint32_t node = 0);
 
 // Overloaded stream send transaction functions for byte, half-word, word and double-word
-extern uint8_t  VStreamSend               (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
-extern uint16_t VStreamSend               (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint32_t VStreamSend               (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint64_t VStreamSend               (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint8_t  VStreamSendAsync          (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
-extern uint16_t VStreamSendAsync          (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint32_t VStreamSendAsync          (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint64_t VStreamSendAsync          (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint8_t  VStreamSend                    (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
+extern uint16_t VStreamSend                    (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint32_t VStreamSend                    (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint64_t VStreamSend                    (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint8_t  VStreamSendAsync               (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
+extern uint16_t VStreamSendAsync               (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint32_t VStreamSendAsync               (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint64_t VStreamSendAsync               (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
 
 // Overloaded stream get transaction functions for byte, half-word, word and double-word
-extern void     VStreamGet                (      uint8_t  *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet                (      uint16_t *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet                (      uint32_t *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet                (      uint64_t *data,       int *stream, const uint32_t node = 0);
+extern void     VStreamGet                     (      uint8_t  *data,       int *stream,   const uint32_t node = 0);
+extern void     VStreamGet                     (      uint16_t *data,       int *stream,   const uint32_t node = 0);
+extern void     VStreamGet                     (      uint32_t *data,       int *stream,   const uint32_t node = 0);
+extern void     VStreamGet                     (      uint64_t *data,       int *stream,   const uint32_t node = 0);
 
 // Stream burst send and get transaction functions
-extern void     VStreamBurstSend          (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
-extern void     VStreamBurstSendAsync     (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
-extern void     VStreamBurstGet           (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
+extern void     VStreamBurstSend               (      uint8_t  *data, const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstSendAsync          (      uint8_t  *data, const int  bytesize, const uint32_t node = 0);
+extern void     VStreamBurstGet                (      uint8_t  *data, const int  bytesize, const uint32_t node = 0);
 
 #endif
 

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -153,6 +153,9 @@ extern uint64_t  VTransUserCommon               (const int op, const uint64_t ad
 extern void      VTransBurstCommon              (const int op, const int param, const uint32_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 extern void      VTransBurstCommon              (const int op, const int param, const uint64_t addr, uint8_t* data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 
+extern int       VTransGetCount                 (const int op, const uint32_t node = 0);
+extern void      VTransTransactionWait          (const int op, const uint32_t node = 0);
+
 // Overloaded stream send/check common transaction functions for byte, half-word, word and double-word
 extern uint8_t   VStreamUserCommon              (const int op, const uint8_t   data, const int  param = 0,  const uint32_t node = 0);
 extern uint16_t  VStreamUserCommon              (const int op, const uint16_t  data, const int  param = 0,  const uint32_t node = 0);
@@ -168,6 +171,8 @@ extern bool      VStreamUserGetCommon           (const int op, uint64_t *rdata, 
 // Stream burst send and get common transaction functions
 extern bool      VStreamUserBurstSendCommon     (const int op, const int burst_type, uint8_t* data, const int bytesize, const int param = 0, const uint32_t node = 0);
 extern bool      VStreamUserBurstGetCommon      (const int op, const int param,      uint8_t* data, const int bytesize, int* status,         const uint32_t node = 0);
+
+extern int       VStreamWaitGetCount            (const int op, const bool txnrx, const uint32_t node = 0);
 
 # endif
 

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -132,117 +132,150 @@ typedef void (*pVUserMain_t)(void);
 #ifdef __cplusplus
 
 // Function to advance simulation by a number of clock ticks
-extern int      VTick                   (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
+extern int      VTick                     (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
 
 // GHDL main support function to wait for simultion to be ready to call
-extern void     VWaitForSim             (const uint32_t node = 0);
+extern void     VWaitForSim               (const uint32_t node = 0);
 
 // OSVVM support function to set the test name
-extern void     VSetTestName            (const char* data, const int bytesize, const uint32_t node);
+extern void     VSetTestName              (const char* data, const int bytesize, const uint32_t node);
 
 // Overloaded write transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word and double-word
-extern uint8_t  VTransWrite             (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWrite             (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWrite             (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint8_t  VTransWrite             (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWrite             (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWrite             (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint64_t VTransWrite             (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWrite               (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWrite               (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWrite               (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWrite               (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWrite               (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWrite               (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint64_t VTransWrite               (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded write asynchronous transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word and double-word
-extern uint8_t  VTransWriteAsync        (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWriteAsync        (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWriteAsync        (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint8_t  VTransWriteAsync        (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-extern uint16_t VTransWriteAsync        (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint32_t VTransWriteAsync        (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-extern uint64_t VTransWriteAsync        (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWriteAsync          (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWriteAsync          (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWriteAsync          (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint8_t  VTransWriteAsync          (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern uint16_t VTransWriteAsync          (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint32_t VTransWriteAsync          (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern uint64_t VTransWriteAsync          (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded read transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word, and double-word
-extern void     VTransRead              (const uint32_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead              (const uint32_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead              (const uint32_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead              (const uint64_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead              (const uint64_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead              (const uint64_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
-extern void     VTransRead              (const uint64_t addr,       uint64_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                (const uint32_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                (const uint32_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                (const uint32_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                (const uint64_t addr,       uint8_t  *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                (const uint64_t addr,       uint16_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                (const uint64_t addr,       uint32_t *data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransRead                (const uint64_t addr,       uint64_t *data, const int prot = 0, const uint32_t node = 0);
+
+extern void     VTransReadCheck           (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck           (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck           (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck           (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck           (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck           (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+extern void     VTransReadCheck           (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded write-read transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word and double-word
-uint8_t         VTransWriteAndRead      (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndRead      (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndRead      (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint8_t         VTransWriteAndRead      (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndRead      (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndRead      (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint64_t        VTransWriteAndRead      (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndRead        (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndRead        (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndRead        (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndRead        (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndRead        (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndRead        (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint64_t        VTransWriteAndRead        (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded write-read asynchronous transaction functions for 32 and 64 bit architecture for byte,
 // half-word, word and double-word
-uint8_t         VTransWriteAndReadAsync (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndReadAsync (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndReadAsync (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint8_t         VTransWriteAndReadAsync (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
-uint16_t        VTransWriteAndReadAsync (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
-uint32_t        VTransWriteAndReadAsync (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
-uint64_t        VTransWriteAndReadAsync (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndReadAsync   (const uint32_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndReadAsync   (const uint32_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndReadAsync   (const uint32_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint8_t         VTransWriteAndReadAsync   (const uint64_t addr, const uint8_t   data, const int prot = 0, const uint32_t node = 0);
+uint16_t        VTransWriteAndReadAsync   (const uint64_t addr, const uint16_t  data, const int prot = 0, const uint32_t node = 0);
+uint32_t        VTransWriteAndReadAsync   (const uint64_t addr, const uint32_t  data, const int prot = 0, const uint32_t node = 0);
+uint64_t        VTransWriteAndReadAsync   (const uint64_t addr, const uint64_t  data, const int prot = 0, const uint32_t node = 0);
 
-// Overloaded write address asynchronous transaction functions for 32 and 64 bit architecture 
-void            VTransWriteAddressAsync (const uint32_t addr, const uint32_t node = 0);
-void            VTransWriteAddressAsync (const uint64_t addr, const uint32_t node = 0);
+// Overloaded write address asynchronous transaction functions for 32 and 64 bit architecture
+void            VTransWriteAddressAsync   (const uint32_t addr, const uint32_t node = 0);
+void            VTransWriteAddressAsync   (const uint64_t addr, const uint32_t node = 0);
 
 // Overloaded write data transaction functions for byte, half-word, word and double-word
-void            VTransWriteDataAsync    (const uint8_t  data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync    (const uint16_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync    (const uint32_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
-void            VTransWriteDataAsync    (const uint64_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync      (const uint8_t  data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync      (const uint16_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync      (const uint32_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
+void            VTransWriteDataAsync      (const uint64_t data, const uint32_t bytelane = 0, const uint32_t node = 0);
 
 // Overloaded read address asynchronous transaction functions for 32 and 64 bit architecture
-void            VTransReadAddressAsync  (const uint32_t addr, const uint32_t node = 0);
-void            VTransReadAddressAsync  (const uint64_t addr, const uint32_t node = 0);
+void            VTransReadAddressAsync    (const uint32_t addr, const uint32_t node = 0);
+void            VTransReadAddressAsync    (const uint64_t addr, const uint32_t node = 0);
 
 // Overloaded write data transaction functions for byte, half-word, word and double-word
-void            VTransReadData          (uint8_t       *data, const uint32_t node = 0);
-void            VTransReadData          (uint16_t      *data, const uint32_t node = 0);
-void            VTransReadData          (uint32_t      *data, const uint32_t node = 0);
-void            VTransReadData          (uint64_t      *data, const uint32_t node = 0);
+void            VTransReadData            (uint8_t       *data, const uint32_t node = 0);
+void            VTransReadData            (uint16_t      *data, const uint32_t node = 0);
+void            VTransReadData            (uint32_t      *data, const uint32_t node = 0);
+void            VTransReadData            (uint64_t      *data, const uint32_t node = 0);
+
+bool            VTransTryReadData         (uint8_t       *data, const uint32_t node = 0);
+bool            VTransTryReadData         (uint16_t      *data, const uint32_t node = 0);
+bool            VTransTryReadData         (uint32_t      *data, const uint32_t node = 0);
+bool            VTransTryReadData         (uint64_t      *data, const uint32_t node = 0);
+
+// Overloaded write data transaction functions for byte, half-word, word and double-word
+void            VTransReadCheckData       (uint8_t        data, const uint32_t node = 0);
+void            VTransReadCheckData       (uint16_t       data, const uint32_t node = 0);
+void            VTransReadCheckData       (uint32_t       data, const uint32_t node = 0);
+void            VTransReadCheckData       (uint64_t       data, const uint32_t node = 0);
+
+bool            VTransTryReadCheckData    (uint8_t        data, const uint32_t node = 0);
+bool            VTransTryReadCheckData    (uint16_t       data, const uint32_t node = 0);
+bool            VTransTryReadCheckData    (uint32_t       data, const uint32_t node = 0);
+bool            VTransTryReadCheckData    (uint64_t       data, const uint32_t node = 0);
 
 // Overloaded write burst transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstWrite        (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWrite        (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-
-// Overloaded write burst asynchronous transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstWriteAsync   (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstWriteAsync   (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite          (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWrite          (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteAsync     (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteAsync     (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrement      (const uint32_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrement      (const uint64_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrementAsync (const uint32_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteIncrementAsync (const uint64_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandom         (const uint32_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandom         (const uint64_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandomAsync    (const uint32_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstWriteRandomAsync    (const uint64_t addr, uint8_t *data, const int count, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded read burst transaction functions for 32 and 64 bit architecture
-extern void     VTransBurstRead         (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
-extern void     VTransBurstRead         (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead           (const uint32_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransBurstRead           (const uint64_t addr, uint8_t  *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadIncrement (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadIncrement (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadRandom    (const uint32_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
+extern void     VTransCheckBurstReadRandom    (const uint64_t addr, uint8_t *data, const int bytesize, const int prot = 0, const uint32_t node = 0);
 
 // Overloaded stream send transaction functions for byte, half-word, word and double-word
-extern uint8_t  VStreamSend             (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
-extern uint16_t VStreamSend             (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint32_t VStreamSend             (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint64_t VStreamSend             (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
-
-extern uint8_t  VStreamSendAsync        (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
-extern uint16_t VStreamSendAsync        (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint32_t VStreamSendAsync        (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
-extern uint64_t VStreamSendAsync        (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint8_t  VStreamSend               (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
+extern uint16_t VStreamSend               (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint32_t VStreamSend               (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint64_t VStreamSend               (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint8_t  VStreamSendAsync          (const uint8_t   data, const int  param = 0, const uint32_t node = 0);
+extern uint16_t VStreamSendAsync          (const uint16_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint32_t VStreamSendAsync          (const uint32_t  data, const int  param = 0, const uint32_t node = 0);
+extern uint64_t VStreamSendAsync          (const uint64_t  data, const int  param = 0, const uint32_t node = 0);
 
 // Overloaded stream get transaction functions for byte, half-word, word and double-word
-extern void     VStreamGet              (      uint8_t  *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet              (      uint16_t *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet              (      uint32_t *data,       int *stream, const uint32_t node = 0);
-extern void     VStreamGet              (      uint64_t *data,       int *stream, const uint32_t node = 0);
+extern void     VStreamGet                (      uint8_t  *data,       int *stream, const uint32_t node = 0);
+extern void     VStreamGet                (      uint16_t *data,       int *stream, const uint32_t node = 0);
+extern void     VStreamGet                (      uint32_t *data,       int *stream, const uint32_t node = 0);
+extern void     VStreamGet                (      uint64_t *data,       int *stream, const uint32_t node = 0);
 
-// Stream burst send and get transaction functions 
-extern void     VStreamBurstSend        (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
-extern void     VStreamBurstSendAsync   (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
-extern void     VStreamBurstGet         (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
+// Stream burst send and get transaction functions
+extern void     VStreamBurstSend          (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
+extern void     VStreamBurstSendAsync     (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
+extern void     VStreamBurstGet           (      uint8_t  *data, const int      bytesize, const uint32_t node = 0);
 
 #endif
 

--- a/code/OsvvmVUser.h
+++ b/code/OsvvmVUser.h
@@ -15,8 +15,8 @@
 //
 //  Revision History:
 //    Date      Version    Description
-//    05/2023   2023.05    Adding Async, Try and Check transaction support
-//    03/2023   2023.04    Adding basic stream support
+//    05/2023   2023.05    Adding support for Async, Try and Check transactions
+//                         and address bus repsonder
 //    01/2023   2023.01    Initial revision
 //
 //
@@ -47,20 +47,9 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
-#define EXTC  "C"
-extern "C"
-{
-#else
-#define EXTC
-#endif
-
 #include "OsvvmVProc.h"
 #include "OsvvmVSchedPli.h"
 
-#ifdef __cplusplus
-}
-#endif
 // -------------------------------------------------------------------------
 // DEFINES AND MACROS
 // -------------------------------------------------------------------------
@@ -97,12 +86,7 @@ extern "C"
                               printf (formbuf, ##__VA_ARGS__);                     \
                               }
 #  else
-// If compiled under C++, io_printf() uses PLI_BYTE* which can't have const char* cast,
-// so use buffers for a format string and single string buffer argument, and sprintf to
-// format the string into the msg buffer
-//# define VPrint(...) {char __msg[4096], fmt[10]; strcpy(fmt, "%s");sprintf(__msg, __VA_ARGS__); io_printf(fmt, __msg);}
 #  define VPrint(...) {printf(__VA_ARGS__);}
-
 #  endif
 # else
 #  define VPrint(...) {vhpi_printf(__VA_ARGS__);}
@@ -129,7 +113,6 @@ typedef void (*pVUserMain_t)(void);
 // -------------------------------------------------------------------------
 
 // VUser function prototypes
-# ifdef __cplusplus
 
 // Function to advance simulation by a number of clock ticks
 extern int       VTick                          (const uint32_t ticks, const bool done = false, const bool error = false, const uint32_t  node = 0);
@@ -174,12 +157,10 @@ extern bool      VStreamUserBurstGetCommon      (const int op, const int param, 
 
 extern int       VStreamWaitGetCount            (const int op, const bool txnrx, const uint32_t node = 0);
 
-# endif
-
 // User function called from VInit to instigate new user thread
-extern EXTC int  VUser                          (const int node);
+extern int       VUser                          (const int node);
 
 // User interrupt callback registering function
-extern EXTC void VRegInterrupt                  (const pVUserInt_t func, const uint32_t node);
+extern void      VRegInterrupt                  (const pVUserInt_t func, const uint32_t node);
 
 #endif

--- a/makefile
+++ b/makefile
@@ -138,9 +138,6 @@ CFLAGS             = -fPIC                                 \
 
 all: ${VPROC_PLI} ${VUSER_PLI}
 
-${VOBJDIR}/%.o: ${SRCDIR}/%.c ${SRC_INCL}
-	@${CC} -c ${CFLAGS} ${USRFLAGS} $< -o $@
-
 ${VOBJDIR}/%.o: ${SRCDIR}/%.cpp ${SRC_INCL}
 	@${C++} -c ${CFLAGS} ${USRFLAGS} $< -o $@
 

--- a/makefile
+++ b/makefile
@@ -90,8 +90,6 @@ else ifeq ("${SIM}", "RivieraPRO")
   endif
 else ifeq ("${SIM}", "ModelSim")
   TOOLFLAGS        = -m32 -DSIEMENS
-else
-  $(error "Unrecognized SIM type in CoSim/makefile")
 endif
 
 RV32EXE            = test.exe

--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@
 #   USRCDIR     : Directory where the test source directory is located
 #   OPDIR       : Directory for compilation output
 #   USRFLAGS    : Additional user defined compile and link flags
-#   SIM         : The target simulator. One of GHDL, NVC, RivieraPRO, 
+#   SIM         : The target simulator. One of GHDL, NVC, RivieraPRO,
 #                 QuestaSim, or ModelSim
 #   ALDECDIR    : Location of RivieraPRO installation, when selected by SIM
 #
@@ -61,7 +61,7 @@ VPROC_CPP_BASE     = $(notdir $(filter %cpp, ${VPROC_C}))
 
 # Test user code
 USER_C             = $(wildcard ${USRCDIR}/*.c*)
-EXCLFILE           = 
+EXCLFILE           =
 USER_CPP_BASE      = $(patsubst ${EXCLFILE},,$(notdir $(filter %cpp, ${USER_C})))
 USER_C_BASE        = $(notdir $(filter %c, ${USER_C}))
 
@@ -73,17 +73,25 @@ VUOBJS             = $(addprefix ${VOBJDIR}/, ${USER_C_BASE:%.c=%.o}  ${USER_CPP
 
 VPROCLIBSUFFIX     = so
 
-ifeq ("${SIM}", "GHDL")
-  TOOLFLAGS        = -m64
-else ifeq ("${SIM}", "NVC")
-  TOOLFLAGS        = -m64
-else ifeq ("${SIM}", "QuestaSim")
-  TOOLFLAGS        = -m64 -DSIEMENS
+# Get OS type
+OSTYPE:=$(shell uname)
+
+TOOLFLAGS          = -m64
+
+ifeq ("${SIM}", "QuestaSim")
+  TOOLFLAGS        += -DSIEMENS
 else ifeq ("${SIM}", "RivieraPRO")
   ALDECDIR         =  /c/Aldec/Riviera-PRO-2022.10-x64
-  TOOLFLAGS        = -m64 -DALDEC -I${ALDECDIR}/interfaces/include -L${ALDECDIR}/interfaces/lib -l:aldecpli.lib
-else
+  TOOLFLAGS        += -DALDEC -I${ALDECDIR}/interfaces/include
+  ifeq (${OSTYPE}, Linux)
+    TOOLFLAGS      += -L${ALDECDIR}/bin -laldecpli
+  else
+    TOOLFLAGS      += -L${ALDECDIR}/interfaces/lib -l:aldecpli.lib
+  endif
+else ifeq ("${SIM}", "ModelSim")
   TOOLFLAGS        = -m32 -DSIEMENS
+else
+  $(error "Unrecognized SIM type in CoSim/makefile")
 endif
 
 RV32EXE            = test.exe
@@ -101,9 +109,6 @@ VLIB               = ${TESTDIR}/libvproc.a
 
 VUSER_PLI          = ${OPDIR}/VUser.so
 VULIB              = ${TESTDIR}/libvuser.a
-
-# Get OS type
-OSTYPE:=$(shell uname)
 
 # Set OS specific variables between Linux and Windows (MinGW)
 ifeq (${OSTYPE}, Linux)

--- a/makefile.ghdl
+++ b/makefile.ghdl
@@ -142,7 +142,7 @@ ${USRCODE} ${COSIMCODE}:
                 USRCDIR=${CTESTDIR}                                       \
                 OPDIR=${OPDIR}                                            \
                 EXCLFILE=${MAINSRC}                                       \
-                USRFLAGS="-I./include -L./lib -DDISABLE_VUSERMAIN_THREAD ${USRFLAGS}"
+                USRFLAGS="-I./include -L./lib -DGHDL -DDISABLE_VUSERMAIN_THREAD ${USRFLAGS}"
 
 #
 # Collect all the user objects in VHDL_LIBS and all the relevant objects

--- a/src/OsvvmTestCoSimPkg.vhd
+++ b/src/OsvvmTestCoSimPkg.vhd
@@ -240,7 +240,7 @@ package body OsvvmTestCoSimPkg is
       VPData     := to_integer(signed(RdData(31 downto  0))) ;
       VPDataHi   := to_integer(signed(RdData(RdData'length-1 downto 32))) ;
     else
-      VPData     := to_integer(signed(RdData(31 downto 0))) ;
+      VPData     := to_integer(signed(RdData(RdData'length-1 downto 0))) ;
       VPDataHi   := 0 ;
     end if;
 

--- a/src/OsvvmVprocAldecPkg.vhd
+++ b/src/OsvvmVprocAldecPkg.vhd
@@ -13,12 +13,13 @@
 --
 --  Revision History:
 --    Date      Version    Description
+--    05/2023   2023.05    Refactoring to support repsonder and stream functionality
 --    09/2022   2023.01    Initial revision
 --
 --
 --  This file is part of OSVVM.
 --
---  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+--  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.
@@ -46,10 +47,8 @@ package OsvvmVprocPkg is
     VPStatus    : in    integer ;
     VPCount     : in    integer ;
     VPCountSec  : in    integer ;
-    VPDataIn    : in    integer ;
-    VPDataInHi  : in    integer ;
-    VPDataOut   : out   integer ;
-    VPDataOutHi : out   integer ;
+    VPData      : inout integer ;
+    VPDataHi    : inout integer ;
     VPDataWidth : out   integer ;
     VPAddr      : inout integer ;
     VPAddrHi    : inout integer ;
@@ -94,10 +93,8 @@ package body OsvvmVprocPkg is
     VPStatus    : in    integer ;
     VPCount     : in    integer ;
     VPCountSec  : in    integer ;
-    VPDataIn    : in    integer ;
-    VPDataInHi  : in    integer ;
-    VPDataOut   : out   integer ;
-    VPDataOutHi : out   integer ;
+    VPData      : inout integer ;
+    VPDataHi    : inout integer ;
     VPDataWidth : out   integer ;
     VPAddr      : inout integer ;
     VPAddrHi    : inout integer ;

--- a/src/OsvvmVprocAldecPkg.vhd
+++ b/src/OsvvmVprocAldecPkg.vhd
@@ -41,25 +41,25 @@ package OsvvmVprocPkg is
   attribute foreign of VInit : procedure is "VHPI VProc.so; VInit" ;
 
   procedure VTrans (
-    node        : in  integer ;
-    Interrupt   : in  integer ;
-    VPStatus    : in  integer ;
-    VPCount     : in  integer ;
-    VPCountSec  : in  integer ;
-    VPDataIn    : in  integer ;
-    VPDataInHi  : in  integer ;
-    VPDataOut   : out integer ;
-    VPDataOutHi : out integer ;
-    VPDataWidth : out integer ;
-    VPAddr      : out integer ;
-    VPAddrHi    : out integer ;
-    VPAddrWidth : out integer ;
-    VPOp        : out integer ;
-    VPBurstSize : out integer ;
-    VPTicks     : out integer ;
-    VPDone      : out integer ;
-    VPError     : out integer ;
-    VPParam     : out integer
+    node        : in    integer ;
+    Interrupt   : in    integer ;
+    VPStatus    : in    integer ;
+    VPCount     : in    integer ;
+    VPCountSec  : in    integer ;
+    VPDataIn    : in    integer ;
+    VPDataInHi  : in    integer ;
+    VPDataOut   : out   integer ;
+    VPDataOutHi : out   integer ;
+    VPDataWidth : out   integer ;
+    VPAddr      : inout integer ;
+    VPAddrHi    : inout integer ;
+    VPAddrWidth : out   integer ;
+    VPOp        : out   integer ;
+    VPBurstSize : out   integer ;
+    VPTicks     : out   integer ;
+    VPDone      : out   integer ;
+    VPError     : out   integer ;
+    VPParam     : out   integer
   ) ;
   attribute foreign of VTrans : procedure is "VHPI VProc.so; VTrans" ;
 
@@ -89,25 +89,25 @@ package body OsvvmVprocPkg is
   end ;
 
   procedure VTrans (
-    node        : in  integer ;
-    Interrupt   : in  integer ;
-    VPStatus    : in  integer ;
-    VPCount     : in  integer ;
-    VPCountSec   : in  integer ;
-    VPDataIn    : in  integer ;
-    VPDataInHi  : in  integer ;
-    VPDataOut   : out integer ;
-    VPDataOutHi : out integer ;
-    VPDataWidth : out integer ;
-    VPAddr      : out integer ;
-    VPAddrHi    : out integer ;
-    VPAddrWidth : out integer ;
-    VPOp        : out integer ;
-    VPBurstSize : out integer ;
-    VPTicks     : out integer ;
-    VPDone      : out integer ;
-    VPError     : out integer ;
-    VPParam     : out integer
+    node        : in    integer ;
+    Interrupt   : in    integer ;
+    VPStatus    : in    integer ;
+    VPCount     : in    integer ;
+    VPCountSec  : in    integer ;
+    VPDataIn    : in    integer ;
+    VPDataInHi  : in    integer ;
+    VPDataOut   : out   integer ;
+    VPDataOutHi : out   integer ;
+    VPDataWidth : out   integer ;
+    VPAddr      : inout integer ;
+    VPAddrHi    : inout integer ;
+    VPAddrWidth : out   integer ;
+    VPOp        : out   integer ;
+    VPBurstSize : out   integer ;
+    VPTicks     : out   integer ;
+    VPDone      : out   integer ;
+    VPError     : out   integer ;
+    VPParam     : out   integer
   ) is
   begin
     report "ERROR: foreign subprogram out_params not called" ;

--- a/src/OsvvmVprocAldecPkg.vhd
+++ b/src/OsvvmVprocAldecPkg.vhd
@@ -44,6 +44,8 @@ package OsvvmVprocPkg is
     node        : in  integer ;
     Interrupt   : in  integer ;
     VPStatus    : in  integer ;
+    VPCount     : in  integer ;
+    VPCountSec  : in  integer ;
     VPDataIn    : in  integer ;
     VPDataInHi  : in  integer ;
     VPDataOut   : out integer ;
@@ -90,6 +92,8 @@ package body OsvvmVprocPkg is
     node        : in  integer ;
     Interrupt   : in  integer ;
     VPStatus    : in  integer ;
+    VPCount     : in  integer ;
+    VPCountSec   : in  integer ;
     VPDataIn    : in  integer ;
     VPDataInHi  : in  integer ;
     VPDataOut   : out integer ;

--- a/src/OsvvmVprocGhdlPkg.vhd
+++ b/src/OsvvmVprocGhdlPkg.vhd
@@ -41,25 +41,25 @@ package OsvvmVprocPkg is
   attribute foreign of VInit : procedure is "VHPIDIRECT ./VProc.so VInit" ;
 
   procedure VTrans (
-    node        : in  integer ;
-    Interrupt   : in  integer ;
-    VPStatus    : in  integer ;
-    VPCount     : in  integer ;
-    VPCountSec  : in  integer ;
-    VPDataIn    : in  integer ;
-    VPDataInHi  : in  integer ;
-    VPDataOut   : out integer ;
-    VPDataOutHi : out integer ;
-    VPDataWidth : out integer ;
-    VPAddr      : out integer ;
-    VPAddrHi    : out integer ;
-    VPAddrWidth : out integer ;
-    VPOp        : out integer ;
-    VPBurstSize : out integer ;
-    VPTicks     : out integer ;
-    VPDone      : out integer ;
-    VPError     : out integer ;
-    VPParam     : out integer
+    node        : in    integer ;
+    Interrupt   : in    integer ;
+    VPStatus    : in    integer ;
+    VPCount     : in    integer ;
+    VPCountSec  : in    integer ;
+    VPDataIn    : in    integer ;
+    VPDataInHi  : in    integer ;
+    VPDataOut   : out   integer ;
+    VPDataOutHi : out   integer ;
+    VPDataWidth : out   integer ;
+    VPAddr      : inout integer ;
+    VPAddrHi    : inout integer ;
+    VPAddrWidth : out   integer ;
+    VPOp        : out   integer ;
+    VPBurstSize : out   integer ;
+    VPTicks     : out   integer ;
+    VPDone      : out   integer ;
+    VPError     : out   integer ;
+    VPParam     : out   integer
   ) ;
   attribute foreign of VTrans : procedure is "VHPIDIRECT ./VProc.so VTrans" ;
 
@@ -89,25 +89,25 @@ package body OsvvmVprocPkg is
   end ;
 
   procedure VTrans (
-    node        : in  integer ;
-    Interrupt   : in  integer ;
-    VPStatus    : in  integer ;
-    VPCount     : in  integer ;
-    VPCountSec  : in  integer ;
-    VPDataIn    : in  integer ;
-    VPDataInHi  : in  integer ;
-    VPDataOut   : out integer ;
-    VPDataOutHi : out integer ;
-    VPDataWidth : out integer ;
-    VPAddr      : out integer ;
-    VPAddrHi    : out integer ;
-    VPAddrWidth : out integer ;
-    VPOp        : out integer ;
-    VPBurstSize : out integer ;
-    VPTicks     : out integer ;
-    VPDone      : out integer ;
-    VPError     : out integer ;
-    VPParam     : out integer
+    node        : in    integer ;
+    Interrupt   : in    integer ;
+    VPStatus    : in    integer ;
+    VPCount     : in    integer ;
+    VPCountSec  : in    integer ;
+    VPDataIn    : in    integer ;
+    VPDataInHi  : in    integer ;
+    VPDataOut   : out   integer ;
+    VPDataOutHi : out   integer ;
+    VPDataWidth : out   integer ;
+    VPAddr      : inout integer ;
+    VPAddrHi    : inout integer ;
+    VPAddrWidth : out   integer ;
+    VPOp        : out   integer ;
+    VPBurstSize : out   integer ;
+    VPTicks     : out   integer ;
+    VPDone      : out   integer ;
+    VPError     : out   integer ;
+    VPParam     : out   integer
   ) is
   begin
     report "ERROR: foreign subprogram out_params not called" ;

--- a/src/OsvvmVprocGhdlPkg.vhd
+++ b/src/OsvvmVprocGhdlPkg.vhd
@@ -13,6 +13,7 @@
 --
 --  Revision History:
 --    Date      Version    Description
+--    05/2023   2023.05    Refactoring to support repsonder and stream functionality
 --    09/2022   2023.01    Initial revision
 --
 --
@@ -46,10 +47,8 @@ package OsvvmVprocPkg is
     VPStatus    : in    integer ;
     VPCount     : in    integer ;
     VPCountSec  : in    integer ;
-    VPDataIn    : in    integer ;
-    VPDataInHi  : in    integer ;
-    VPDataOut   : out   integer ;
-    VPDataOutHi : out   integer ;
+    VPData      : inout integer ;
+    VPDataHi    : inout integer ;
     VPDataWidth : out   integer ;
     VPAddr      : inout integer ;
     VPAddrHi    : inout integer ;
@@ -94,10 +93,8 @@ package body OsvvmVprocPkg is
     VPStatus    : in    integer ;
     VPCount     : in    integer ;
     VPCountSec  : in    integer ;
-    VPDataIn    : in    integer ;
-    VPDataInHi  : in    integer ;
-    VPDataOut   : out   integer ;
-    VPDataOutHi : out   integer ;
+    VPData      : inout integer ;
+    VPDataHi    : inout integer ;
     VPDataWidth : out   integer ;
     VPAddr      : inout integer ;
     VPAddrHi    : inout integer ;

--- a/src/OsvvmVprocGhdlPkg.vhd
+++ b/src/OsvvmVprocGhdlPkg.vhd
@@ -44,6 +44,8 @@ package OsvvmVprocPkg is
     node        : in  integer ;
     Interrupt   : in  integer ;
     VPStatus    : in  integer ;
+    VPCount     : in  integer ;
+    VPCountSec  : in  integer ;
     VPDataIn    : in  integer ;
     VPDataInHi  : in  integer ;
     VPDataOut   : out integer ;
@@ -90,6 +92,8 @@ package body OsvvmVprocPkg is
     node        : in  integer ;
     Interrupt   : in  integer ;
     VPStatus    : in  integer ;
+    VPCount     : in  integer ;
+    VPCountSec  : in  integer ;
     VPDataIn    : in  integer ;
     VPDataInHi  : in  integer ;
     VPDataOut   : out integer ;

--- a/src/OsvvmVprocNvcPkg.vhd
+++ b/src/OsvvmVprocNvcPkg.vhd
@@ -41,25 +41,25 @@ package OsvvmVprocPkg is
   attribute foreign of VInit : procedure is "VHPIDIRECT VInit" ;
 
   procedure VTrans (
-    node        : in  integer ;
-    Interrupt   : in  integer ;
-    VPStatus    : in  integer ;
-    VPCount     : in  integer ;
-    VPCountSec  : in  integer ;
-    VPDataIn    : in  integer ;
-    VPDataInHi  : in  integer ;
-    VPDataOut   : out integer ;
-    VPDataOutHi : out integer ;
-    VPDataWidth : out integer ;
-    VPAddr      : out integer ;
-    VPAddrHi    : out integer ;
-    VPAddrWidth : out integer ;
-    VPOp        : out integer ;
-    VPBurstSize : out integer ;
-    VPTicks     : out integer ;
-    VPDone      : out integer ;
-    VPError     : out integer ;
-    VPParam     : out integer
+    node        : in    integer ;
+    Interrupt   : in    integer ;
+    VPStatus    : in    integer ;
+    VPCount     : in    integer ;
+    VPCountSec  : in    integer ;
+    VPDataIn    : in    integer ;
+    VPDataInHi  : in    integer ;
+    VPDataOut   : out   integer ;
+    VPDataOutHi : out   integer ;
+    VPDataWidth : out   integer ;
+    VPAddr      : inout integer ;
+    VPAddrHi    : inout integer ;
+    VPAddrWidth : out   integer ;
+    VPOp        : out   integer ;
+    VPBurstSize : out   integer ;
+    VPTicks     : out   integer ;
+    VPDone      : out   integer ;
+    VPError     : out   integer ;
+    VPParam     : out   integer
   ) ;
   attribute foreign of VTrans : procedure is "VHPIDIRECT VTrans" ;
 
@@ -89,25 +89,25 @@ package body OsvvmVprocPkg is
   end ;
 
   procedure VTrans (
-    node        : in  integer ;
-    Interrupt   : in  integer ;
-    VPStatus    : in  integer ;
-    VPCount     : in  integer ;
-    VPCountSec  : in  integer ;
-    VPDataIn    : in  integer ;
-    VPDataInHi  : in  integer ;
-    VPDataOut   : out integer ;
-    VPDataOutHi : out integer ;
-    VPDataWidth : out integer ;
-    VPAddr      : out integer ;
-    VPAddrHi    : out integer ;
-    VPAddrWidth : out integer ;
-    VPOp        : out integer ;
-    VPBurstSize : out integer ;
-    VPTicks     : out integer ;
-    VPDone      : out integer ;
-    VPError     : out integer ;
-    VPParam     : out integer
+    node        : in    integer ;
+    Interrupt   : in    integer ;
+    VPStatus    : in    integer ;
+    VPCount     : in    integer ;
+    VPCountSec  : in    integer ;
+    VPDataIn    : in    integer ;
+    VPDataInHi  : in    integer ;
+    VPDataOut   : out   integer ;
+    VPDataOutHi : out   integer ;
+    VPDataWidth : out   integer ;
+    VPAddr      : inout integer ;
+    VPAddrHi    : inout integer ;
+    VPAddrWidth : out   integer ;
+    VPOp        : out   integer ;
+    VPBurstSize : out   integer ;
+    VPTicks     : out   integer ;
+    VPDone      : out   integer ;
+    VPError     : out   integer ;
+    VPParam     : out   integer
   ) is
   begin
     report "ERROR: foreign subprogram out_params not called" ;

--- a/src/OsvvmVprocNvcPkg.vhd
+++ b/src/OsvvmVprocNvcPkg.vhd
@@ -13,12 +13,13 @@
 --
 --  Revision History:
 --    Date      Version    Description
+--    05/2023   2023.05    Refactoring to support repsonder and stream functionality
 --    09/2022   2023.01    Initial revision
 --
 --
 --  This file is part of OSVVM.
 --
---  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+--  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.
@@ -46,10 +47,8 @@ package OsvvmVprocPkg is
     VPStatus    : in    integer ;
     VPCount     : in    integer ;
     VPCountSec  : in    integer ;
-    VPDataIn    : in    integer ;
-    VPDataInHi  : in    integer ;
-    VPDataOut   : out   integer ;
-    VPDataOutHi : out   integer ;
+    VPData      : inout integer ;
+    VPDataHi    : inout integer ;
     VPDataWidth : out   integer ;
     VPAddr      : inout integer ;
     VPAddrHi    : inout integer ;
@@ -94,10 +93,8 @@ package body OsvvmVprocPkg is
     VPStatus    : in    integer ;
     VPCount     : in    integer ;
     VPCountSec  : in    integer ;
-    VPDataIn    : in    integer ;
-    VPDataInHi  : in    integer ;
-    VPDataOut   : out   integer ;
-    VPDataOutHi : out   integer ;
+    VPData      : inout integer ;
+    VPDataHi    : inout integer ;
     VPDataWidth : out   integer ;
     VPAddr      : inout integer ;
     VPAddrHi    : inout integer ;

--- a/src/OsvvmVprocNvcPkg.vhd
+++ b/src/OsvvmVprocNvcPkg.vhd
@@ -44,6 +44,8 @@ package OsvvmVprocPkg is
     node        : in  integer ;
     Interrupt   : in  integer ;
     VPStatus    : in  integer ;
+    VPCount     : in  integer ;
+    VPCountSec  : in  integer ;
     VPDataIn    : in  integer ;
     VPDataInHi  : in  integer ;
     VPDataOut   : out integer ;
@@ -90,6 +92,8 @@ package body OsvvmVprocPkg is
     node        : in  integer ;
     Interrupt   : in  integer ;
     VPStatus    : in  integer ;
+    VPCount     : in  integer ;
+    VPCountSec  : in  integer ;
     VPDataIn    : in  integer ;
     VPDataInHi  : in  integer ;
     VPDataOut   : out integer ;

--- a/src/OsvvmVprocPkg.vhd
+++ b/src/OsvvmVprocPkg.vhd
@@ -13,12 +13,13 @@
 --
 --  Revision History:
 --    Date      Version    Description
+--    05/2023   2023.05    Refactoring to support repsonder and stream functionality
 --    09/2022   2023.01    Initial revision
 --
 --
 --  This file is part of OSVVM.
 --
---  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+--  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.
@@ -46,10 +47,8 @@ package OsvvmVprocPkg is
     VPStatus    : in    integer ;
     VPCount     : in    integer ;
     VPCountSec  : in    integer ;
-    VPDataIn    : in    integer ;
-    VPDataInHi  : in    integer ;
-    VPDataOut   : out   integer ;
-    VPDataOutHi : out   integer ;
+    VPData      : inout integer ;
+    VPDataHi    : inout integer ;
     VPDataWidth : out   integer ;
     VPAddr      : inout integer ;
     VPAddrHi    : inout integer ;
@@ -94,10 +93,8 @@ package body OsvvmVprocPkg is
     VPStatus    : in    integer ;
     VPCount     : in    integer ;
     VPCountSec  : in    integer ;
-    VPDataIn    : in    integer ;
-    VPDataInHi  : in    integer ;
-    VPDataOut   : out   integer ;
-    VPDataOutHi : out   integer ;
+    VPData      : inout integer ;
+    VPDataHi    : inout integer ;
     VPDataWidth : out   integer ;
     VPAddr      : inout integer ;
     VPAddrHi    : inout integer ;

--- a/src/OsvvmVprocPkg.vhd
+++ b/src/OsvvmVprocPkg.vhd
@@ -41,25 +41,25 @@ package OsvvmVprocPkg is
   attribute foreign of VInit : procedure is "VInit VProc.so" ;
 
   procedure VTrans (
-    node        : in  integer ;
-    Interrupt   : in  integer ;
-    VPStatus    : in  integer ;
-    VPCount     : in  integer ;
-    VPCountSec  : in  integer ;
-    VPDataIn    : in  integer ;
-    VPDataInHi  : in  integer ;
-    VPDataOut   : out integer ;
-    VPDataOutHi : out integer ;
-    VPDataWidth : out integer ;
-    VPAddr      : out integer ;
-    VPAddrHi    : out integer ;
-    VPAddrWidth : out integer ;
-    VPOp        : out integer ;
-    VPBurstSize : out integer ;
-    VPTicks     : out integer ;
-    VPDone      : out integer ;
-    VPError     : out integer ;
-    VPParam     : out integer
+    node        : in    integer ;
+    Interrupt   : in    integer ;
+    VPStatus    : in    integer ;
+    VPCount     : in    integer ;
+    VPCountSec  : in    integer ;
+    VPDataIn    : in    integer ;
+    VPDataInHi  : in    integer ;
+    VPDataOut   : out   integer ;
+    VPDataOutHi : out   integer ;
+    VPDataWidth : out   integer ;
+    VPAddr      : inout integer ;
+    VPAddrHi    : inout integer ;
+    VPAddrWidth : out   integer ;
+    VPOp        : out   integer ;
+    VPBurstSize : out   integer ;
+    VPTicks     : out   integer ;
+    VPDone      : out   integer ;
+    VPError     : out   integer ;
+    VPParam     : out   integer
   ) ;
   attribute foreign of VTrans : procedure is "VTrans VProc.so" ;
 
@@ -89,25 +89,25 @@ package body OsvvmVprocPkg is
   end ;
 
   procedure VTrans (
-    node        : in  integer ;
-    Interrupt   : in  integer ;
-    VPStatus    : in  integer ;
-    VPCount     : in  integer ;
-    VPCountSec  : in  integer ;
-    VPDataIn    : in  integer ;
-    VPDataInHi  : in  integer ;
-    VPDataOut   : out integer ;
-    VPDataOutHi : out integer ;
-    VPDataWidth : out integer ;
-    VPAddr      : out integer ;
-    VPAddrHi    : out integer ;
-    VPAddrWidth : out integer ;
-    VPOp        : out integer ;
-    VPBurstSize : out integer ;
-    VPTicks     : out integer ;
-    VPDone      : out integer ;
-    VPError     : out integer ;
-    VPParam     : out integer
+    node        : in    integer ;
+    Interrupt   : in    integer ;
+    VPStatus    : in    integer ;
+    VPCount     : in    integer ;
+    VPCountSec  : in    integer ;
+    VPDataIn    : in    integer ;
+    VPDataInHi  : in    integer ;
+    VPDataOut   : out   integer ;
+    VPDataOutHi : out   integer ;
+    VPDataWidth : out   integer ;
+    VPAddr      : inout integer ;
+    VPAddrHi    : inout integer ;
+    VPAddrWidth : out   integer ;
+    VPOp        : out   integer ;
+    VPBurstSize : out   integer ;
+    VPTicks     : out   integer ;
+    VPDone      : out   integer ;
+    VPError     : out   integer ;
+    VPParam     : out   integer
   ) is
   begin
     report "ERROR: foreign subprogram out_params not called" ;

--- a/src/OsvvmVprocPkg.vhd
+++ b/src/OsvvmVprocPkg.vhd
@@ -44,6 +44,8 @@ package OsvvmVprocPkg is
     node        : in  integer ;
     Interrupt   : in  integer ;
     VPStatus    : in  integer ;
+    VPCount     : in  integer ;
+    VPCountSec  : in  integer ;
     VPDataIn    : in  integer ;
     VPDataInHi  : in  integer ;
     VPDataOut   : out integer ;
@@ -90,6 +92,8 @@ package body OsvvmVprocPkg is
     node        : in  integer ;
     Interrupt   : in  integer ;
     VPStatus    : in  integer ;
+    VPCount     : in  integer ;
+    VPCountSec  : in  integer ;
     VPDataIn    : in  integer ;
     VPDataInHi  : in  integer ;
     VPDataOut   : out integer ;

--- a/testbench/TbAxi4/tests.pro
+++ b/testbench/TbAxi4/tests.pro
@@ -59,6 +59,10 @@ MkVproc    iss rv32
 TestName   CoSim_iss
 simulate   TbAb_CoSim [CoSim]
 
+MkVproc    async_trans
+TestName   CoSim_async_trans
+simulate   TbAb_CoSim [CoSim]
+
 # MkVprocSkt $::osvvm::OsvvmCoSimDirectory/tests/socket
 # simulate   TbAb_CoSim
 # 

--- a/testbench/TbAxi4Stream/TbAxi4Stream.pro
+++ b/testbench/TbAxi4Stream/TbAxi4Stream.pro
@@ -37,6 +37,7 @@
 #  limitations under the License.
 #  
 
+TestSuite Cosim_Axi4Stream
 library osvvm_cosim_TbAxiStream
 
 analyze TestCtrl_e.vhd

--- a/testbench/TbAxi4_ReadPoll/TbAxi4.vhd
+++ b/testbench/TbAxi4_ReadPoll/TbAxi4.vhd
@@ -1,0 +1,198 @@
+--
+--  File Name:         TbAxi4.vhd
+--  Design Unit Name:  TbAxi4
+--  Revision:          OSVVM MODELS STANDARD VERSION
+--
+--  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+--  Contributor(s):
+--     Jim Lewis      jim@synthworks.com
+--
+--
+--  Description:
+--      Simple AXI Lite Manager Model
+--
+--
+--  Developed by:
+--        SynthWorks Design Inc.
+--        VHDL Training Classes
+--        http://www.SynthWorks.com
+--
+--  Revision History:
+--    Date      Version    Description
+--    04/2018   2018       Initial revision
+--    01/2020   2020.01    Updated license notice
+--    12/2020   2020.12    Updated signal and port names
+--
+--
+--  This file is part of OSVVM.
+--
+--  Copyright (c) 2018 - 2020 by SynthWorks Design Inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+
+library ieee ;
+  use ieee.std_logic_1164.all ;
+  use ieee.numeric_std.all ;
+  use ieee.numeric_std_unsigned.all ;
+
+library osvvm ;
+  context osvvm.OsvvmContext ;
+
+library OSVVM_AXI4 ;
+  context OSVVM_AXI4.Axi4Context ;
+
+entity TbAxi4 is
+end entity TbAxi4 ;
+architecture TestHarness of TbAxi4 is
+  constant AXI_ADDR_WIDTH : integer := 32 ;
+  constant AXI_DATA_WIDTH : integer := 32 ;
+  constant AXI_STRB_WIDTH : integer := AXI_DATA_WIDTH/8 ;
+
+
+  constant tperiod_Clk : time := 10 ns ;
+  constant tpd         : time := 2 ns ;
+
+  signal Clk         : std_logic ;
+  signal nReset      : std_logic ;
+
+--  -- Testbench Transaction Interface
+--  subtype LocalTransactionRecType is AddressBusRecType(
+--    Address(AXI_ADDR_WIDTH-1 downto 0),
+--    DataToModel(AXI_DATA_WIDTH-1 downto 0),
+--    DataFromModel(AXI_DATA_WIDTH-1 downto 0)
+--  ) ;
+--  signal ManagerRec   : LocalTransactionRecType ;
+--  signal SubordinateRec  : LocalTransactionRecType ;
+  signal ManagerRec, SubordinateRec  : AddressBusRecType (
+          Address(AXI_ADDR_WIDTH-1 downto 0),
+          DataToModel(AXI_DATA_WIDTH-1 downto 0),
+          DataFromModel(AXI_DATA_WIDTH-1 downto 0)
+        ) ;
+
+--  -- AXI Manager Functional Interface
+--  signal   AxiBus : Axi4RecType(
+--    WriteAddress( AWAddr(AXI_ADDR_WIDTH-1 downto 0) ),
+--    WriteData   ( WData (AXI_DATA_WIDTH-1 downto 0),   WStrb(AXI_STRB_WIDTH-1 downto 0) ),
+--    ReadAddress ( ARAddr(AXI_ADDR_WIDTH-1 downto 0) ),
+--    ReadData    ( RData (AXI_DATA_WIDTH-1 downto 0) )
+--  ) ;
+
+  signal   AxiBus : Axi4RecType(
+    WriteAddress(
+      Addr(AXI_ADDR_WIDTH-1 downto 0),
+      ID(7 downto 0),
+      User(7 downto 0)
+    ),
+    WriteData   (
+      Data(AXI_DATA_WIDTH-1 downto 0),
+      Strb(AXI_STRB_WIDTH-1 downto 0),
+      User(7 downto 0),
+      ID(7 downto 0)
+    ),
+    WriteResponse(
+      ID(7 downto 0),
+      User(7 downto 0)
+    ),
+    ReadAddress (
+      Addr(AXI_ADDR_WIDTH-1 downto 0),
+      ID(7 downto 0),
+      User(7 downto 0)
+    ),
+    ReadData    (
+      Data(AXI_DATA_WIDTH-1 downto 0),
+      ID(7 downto 0),
+      User(7 downto 0)
+    )
+  ) ;
+
+
+  component TestCtrl is
+    port (
+      -- Global Signal Interface
+      nReset         : In    std_logic ;
+
+      -- Transaction Interfaces
+      ManagerRec      : inout AddressBusRecType ;
+      SubordinateRec   : inout AddressBusRecType
+    ) ;
+  end component TestCtrl ;
+
+
+begin
+
+  -- create Clock
+  Osvvm.TbUtilPkg.CreateClock (
+    Clk        => Clk,
+    Period     => Tperiod_Clk
+  )  ;
+
+  -- create nReset
+  Osvvm.TbUtilPkg.CreateReset (
+    Reset       => nReset,
+    ResetActive => '0',
+    Clk         => Clk,
+    Period      => 7 * tperiod_Clk,
+    tpd         => tpd
+  ) ;
+
+  -- Behavioral model.  Replaces DUT for labs
+  Subordinate_1 : Axi4Subordinate
+  port map (
+    -- Globals
+    Clk         => Clk,
+    nReset      => nReset,
+
+    -- AXI Manager Functional Interface
+    AxiBus  => AxiBus,
+
+    -- Testbench Transaction Interface
+    TransRec    => SubordinateRec
+  ) ;
+
+  Manager_1 : Axi4Manager
+  port map (
+    -- Globals
+    Clk         => Clk,
+    nReset      => nReset,
+
+    -- AXI Manager Functional Interface
+    AxiBus      => AxiBus,
+
+    -- Testbench Transaction Interface
+    TransRec    => ManagerRec
+  ) ;
+
+
+  Monitor_1 : Axi4Monitor
+  port map (
+    -- Globals
+    Clk         => Clk,
+    nReset      => nReset,
+
+    -- AXI Manager Functional Interface
+    AxiBus      => AxiBus
+  ) ;
+
+
+  TestCtrl_1 : TestCtrl
+  port map (
+    -- Global Signal Interface
+    nReset        => nReset,
+
+    -- Transaction Interfaces
+    ManagerRec     => ManagerRec,
+    SubordinateRec  => SubordinateRec
+  ) ;
+
+end architecture TestHarness ;

--- a/testbench/TbAxi4_ReadPoll/TbAxi4_ReadPoll.pro
+++ b/testbench/TbAxi4_ReadPoll/TbAxi4_ReadPoll.pro
@@ -1,0 +1,47 @@
+#  File Name:         TbAxi4.pro
+#  Revision:          STANDARD VERSION
+#
+#  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+#  Contributor(s):
+#     Jim Lewis      jim@synthworks.com
+#
+#
+#  Description:
+#        Script to analyze Axi4 testbench  
+#
+#  Developed for:
+#        SynthWorks Design Inc.
+#        VHDL Training Classes
+#        11898 SW 128th Ave.  Tigard, Or  97223
+#        http://www.SynthWorks.com
+#
+#  Revision History:
+#    Date      Version    Description
+#    12/2022   2023.01    Copied Axi4Lite/Testbench to CoSim and updated
+#     1/2020   2020.01    Updated Licenses to Apache
+#     1/2019   2019.01    Compile Script for OSVVM
+#
+#
+#  This file is part of OSVVM.
+#  
+#  Copyright (c) 2019 - 2022 by SynthWorks Design Inc.  
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+TestSuite  CoSim_ReadPoll
+library    osvvm_CoSim_TbAxi4
+analyze    TestCtrl_e.vhd
+
+analyze    TbAxi4.vhd 
+analyze    ../TestCases/TbAb_ReadPoll.vhd
+

--- a/testbench/TbAxi4_ReadPoll/TestCtrl_e.vhd
+++ b/testbench/TbAxi4_ReadPoll/TestCtrl_e.vhd
@@ -1,0 +1,79 @@
+--
+--  File Name:         TestCtrl_e.vhd
+--  Design Unit Name:  TestCtrl
+--  Revision:          OSVVM MODELS STANDARD VERSION
+--
+--  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+--  Contributor(s):
+--     Jim Lewis      jim@synthworks.com
+--
+--
+--  Description:
+--      Test transaction source
+--
+--
+--  Developed by:
+--        SynthWorks Design Inc.
+--        VHDL Training Classes
+--        http://www.SynthWorks.com
+--
+--  Revision History:
+--    Date      Version    Description
+--    12/2022   2023.01    Added CoSim Context Reference
+--    10/2022   -          Ported from OsvvmLibraries/Axi4/Testbench
+--
+--
+--  This file is part of OSVVM.
+--  
+--  Copyright (c) 2017 - 2023 by SynthWorks Design Inc.  
+--  
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--  
+--      https://www.apache.org/licenses/LICENSE-2.0
+--  
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--  
+
+library ieee ;
+  use ieee.std_logic_1164.all ;
+  use ieee.numeric_std.all ;
+  use ieee.numeric_std_unsigned.all ;
+  use ieee.math_real.all ;
+  
+library OSVVM ; 
+  context OSVVM.OsvvmContext ; 
+  use osvvm.ScoreboardPkg_slv.all ;
+
+library OSVVM_AXI4 ;
+  context OSVVM_AXI4.Axi4Context ; 
+
+library osvvm_cosim ;
+  context osvvm_cosim.CoSimContext ;
+
+
+entity TestCtrl is
+  port (
+    -- Global Signal Interface
+    nReset            : In    std_logic ;
+
+    -- Transaction Interfaces
+    ManagerRec        : inout AddressBusRecType ;
+    SubordinateRec    : inout AddressBusRecType 
+  ) ;
+  
+  -- Derive AXI interface properties from the ManagerRec
+  constant AXI_ADDR_WIDTH : integer := ManagerRec.Address'length ; 
+  constant AXI_DATA_WIDTH : integer := ManagerRec.DataToModel'length ;  
+  constant AXI_DATA_BYTE_WIDTH : integer := AXI_DATA_WIDTH / 8 ;
+  constant AXI_BYTE_ADDR_WIDTH : integer := integer(ceil(log2(real(AXI_DATA_BYTE_WIDTH)))) ;
+    
+  -- Simplifying access to Burst FIFOs using aliases
+  alias WriteBurstFifo : ScoreboardIdType is ManagerRec.WriteBurstFifo ;
+  alias ReadBurstFifo  : ScoreboardIdType is ManagerRec.ReadBurstFifo ;
+end entity TestCtrl ;

--- a/testbench/TbAxi4_ReadPoll/tests.pro
+++ b/testbench/TbAxi4_ReadPoll/tests.pro
@@ -1,0 +1,49 @@
+#  File Name:               tests.pro
+#  Revision:                OSVVM MODELS STANDARD VERSION
+#
+#  Maintainer:              Simon Southwell      simon.southwell@gmail.com
+#  Contributor(s):
+#     Simon Southwell       simon.southwell@gmail.com
+#     Jim Lewis             jim@synthworks.com
+#
+#
+#  Description:
+#        Script to run Axi4 Lite CoSim tests
+#
+#  Developed for:
+#        SynthWorks Design Inc.
+#        VHDL Training Classes
+#        11898 SW 128th Ave.  Tigard, Or  97223
+#        http://www.SynthWorks.com
+#
+#  Revision History:
+#    Date      Version    Description
+#    12/2022   2023.01    Refactored to source scripts in Scripts/StartUpShared.tcl and 
+#                         analyze CoSim by calling CoSim/CoSim.pro in OsvvmLibraries/OsvvmLibraries.pro
+#     9/2022   --         Initial version
+#
+#
+#  This file is part of OSVVM.
+#
+#  Copyright (c) 2022 by [OSVVM Authors](../../AUTHORS.md)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+library    osvvm_CoSim_TbAxi4
+
+ChangeWorkingDirectory ../../tests
+
+MkVproc    readpoll
+TestName   CoSim_readpoll
+simulate   TbAb_ReadPoll [CoSim]

--- a/testbench/TbAxi4_Responder/TbAxi4.vhd
+++ b/testbench/TbAxi4_Responder/TbAxi4.vhd
@@ -1,0 +1,198 @@
+--
+--  File Name:         TbAxi4.vhd
+--  Design Unit Name:  TbAxi4
+--  Revision:          OSVVM MODELS STANDARD VERSION
+--
+--  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+--  Contributor(s):
+--     Jim Lewis      jim@synthworks.com
+--
+--
+--  Description:
+--      Simple AXI Lite Manager Model
+--
+--
+--  Developed by:
+--        SynthWorks Design Inc.
+--        VHDL Training Classes
+--        http://www.SynthWorks.com
+--
+--  Revision History:
+--    Date      Version    Description
+--    04/2018   2018       Initial revision
+--    01/2020   2020.01    Updated license notice
+--    12/2020   2020.12    Updated signal and port names
+--
+--
+--  This file is part of OSVVM.
+--
+--  Copyright (c) 2018 - 2020 by SynthWorks Design Inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+
+library ieee ;
+  use ieee.std_logic_1164.all ;
+  use ieee.numeric_std.all ;
+  use ieee.numeric_std_unsigned.all ;
+
+library osvvm ;
+  context osvvm.OsvvmContext ;
+
+library OSVVM_AXI4 ;
+  context OSVVM_AXI4.Axi4Context ;
+
+entity TbAxi4 is
+end entity TbAxi4 ;
+architecture TestHarness of TbAxi4 is
+  constant AXI_ADDR_WIDTH : integer := 32 ;
+  constant AXI_DATA_WIDTH : integer := 32 ;
+  constant AXI_STRB_WIDTH : integer := AXI_DATA_WIDTH/8 ;
+
+
+  constant tperiod_Clk : time := 10 ns ;
+  constant tpd         : time := 2 ns ;
+
+  signal Clk         : std_logic ;
+  signal nReset      : std_logic ;
+
+--  -- Testbench Transaction Interface
+--  subtype LocalTransactionRecType is AddressBusRecType(
+--    Address(AXI_ADDR_WIDTH-1 downto 0),
+--    DataToModel(AXI_DATA_WIDTH-1 downto 0),
+--    DataFromModel(AXI_DATA_WIDTH-1 downto 0)
+--  ) ;
+--  signal ManagerRec   : LocalTransactionRecType ;
+--  signal SubordinateRec  : LocalTransactionRecType ;
+  signal ManagerRec, SubordinateRec  : AddressBusRecType (
+          Address(AXI_ADDR_WIDTH-1 downto 0),
+          DataToModel(AXI_DATA_WIDTH-1 downto 0),
+          DataFromModel(AXI_DATA_WIDTH-1 downto 0)
+        ) ;
+
+--  -- AXI Manager Functional Interface
+--  signal   AxiBus : Axi4RecType(
+--    WriteAddress( AWAddr(AXI_ADDR_WIDTH-1 downto 0) ),
+--    WriteData   ( WData (AXI_DATA_WIDTH-1 downto 0),   WStrb(AXI_STRB_WIDTH-1 downto 0) ),
+--    ReadAddress ( ARAddr(AXI_ADDR_WIDTH-1 downto 0) ),
+--    ReadData    ( RData (AXI_DATA_WIDTH-1 downto 0) )
+--  ) ;
+
+  signal   AxiBus : Axi4RecType(
+    WriteAddress(
+      Addr(AXI_ADDR_WIDTH-1 downto 0),
+      ID(7 downto 0),
+      User(7 downto 0)
+    ),
+    WriteData   (
+      Data(AXI_DATA_WIDTH-1 downto 0),
+      Strb(AXI_STRB_WIDTH-1 downto 0),
+      User(7 downto 0),
+      ID(7 downto 0)
+    ),
+    WriteResponse(
+      ID(7 downto 0),
+      User(7 downto 0)
+    ),
+    ReadAddress (
+      Addr(AXI_ADDR_WIDTH-1 downto 0),
+      ID(7 downto 0),
+      User(7 downto 0)
+    ),
+    ReadData    (
+      Data(AXI_DATA_WIDTH-1 downto 0),
+      ID(7 downto 0),
+      User(7 downto 0)
+    )
+  ) ;
+
+
+  component TestCtrl is
+    port (
+      -- Global Signal Interface
+      nReset         : In    std_logic ;
+
+      -- Transaction Interfaces
+      ManagerRec      : inout AddressBusRecType ;
+      SubordinateRec   : inout AddressBusRecType
+    ) ;
+  end component TestCtrl ;
+
+
+begin
+
+  -- create Clock
+  Osvvm.TbUtilPkg.CreateClock (
+    Clk        => Clk,
+    Period     => Tperiod_Clk
+  )  ;
+
+  -- create nReset
+  Osvvm.TbUtilPkg.CreateReset (
+    Reset       => nReset,
+    ResetActive => '0',
+    Clk         => Clk,
+    Period      => 7 * tperiod_Clk,
+    tpd         => tpd
+  ) ;
+
+  -- Behavioral model.  Replaces DUT for labs
+  Subordinate_1 : Axi4Subordinate
+  port map (
+    -- Globals
+    Clk         => Clk,
+    nReset      => nReset,
+
+    -- AXI Manager Functional Interface
+    AxiBus  => AxiBus,
+
+    -- Testbench Transaction Interface
+    TransRec    => SubordinateRec
+  ) ;
+
+  Manager_1 : Axi4Manager
+  port map (
+    -- Globals
+    Clk         => Clk,
+    nReset      => nReset,
+
+    -- AXI Manager Functional Interface
+    AxiBus      => AxiBus,
+
+    -- Testbench Transaction Interface
+    TransRec    => ManagerRec
+  ) ;
+
+
+  Monitor_1 : Axi4Monitor
+  port map (
+    -- Globals
+    Clk         => Clk,
+    nReset      => nReset,
+
+    -- AXI Manager Functional Interface
+    AxiBus      => AxiBus
+  ) ;
+
+
+  TestCtrl_1 : TestCtrl
+  port map (
+    -- Global Signal Interface
+    nReset        => nReset,
+
+    -- Transaction Interfaces
+    ManagerRec     => ManagerRec,
+    SubordinateRec  => SubordinateRec
+  ) ;
+
+end architecture TestHarness ;

--- a/testbench/TbAxi4_Responder/TbAxi4_Responder.pro
+++ b/testbench/TbAxi4_Responder/TbAxi4_Responder.pro
@@ -1,0 +1,47 @@
+#  File Name:         TbAxi4.pro
+#  Revision:          STANDARD VERSION
+#
+#  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+#  Contributor(s):
+#     Jim Lewis      jim@synthworks.com
+#
+#
+#  Description:
+#        Script to analyze Axi4 testbench  
+#
+#  Developed for:
+#        SynthWorks Design Inc.
+#        VHDL Training Classes
+#        11898 SW 128th Ave.  Tigard, Or  97223
+#        http://www.SynthWorks.com
+#
+#  Revision History:
+#    Date      Version    Description
+#    12/2022   2023.01    Copied Axi4Lite/Testbench to CoSim and updated
+#     1/2020   2020.01    Updated Licenses to Apache
+#     1/2019   2019.01    Compile Script for OSVVM
+#
+#
+#  This file is part of OSVVM.
+#  
+#  Copyright (c) 2019 - 2022 by SynthWorks Design Inc.  
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+TestSuite  CoSim_Responder
+library    osvvm_CoSim_TbAxi4
+analyze    TestCtrl_e.vhd
+
+analyze    TbAxi4.vhd 
+analyze    ../TestCases/TbAb_Responder.vhd
+

--- a/testbench/TbAxi4_Responder/TestCtrl_e.vhd
+++ b/testbench/TbAxi4_Responder/TestCtrl_e.vhd
@@ -1,0 +1,79 @@
+--
+--  File Name:         TestCtrl_e.vhd
+--  Design Unit Name:  TestCtrl
+--  Revision:          OSVVM MODELS STANDARD VERSION
+--
+--  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+--  Contributor(s):
+--     Jim Lewis      jim@synthworks.com
+--
+--
+--  Description:
+--      Test transaction source
+--
+--
+--  Developed by:
+--        SynthWorks Design Inc.
+--        VHDL Training Classes
+--        http://www.SynthWorks.com
+--
+--  Revision History:
+--    Date      Version    Description
+--    12/2022   2023.01    Added CoSim Context Reference
+--    10/2022   -          Ported from OsvvmLibraries/Axi4/Testbench
+--
+--
+--  This file is part of OSVVM.
+--  
+--  Copyright (c) 2017 - 2023 by SynthWorks Design Inc.  
+--  
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--  
+--      https://www.apache.org/licenses/LICENSE-2.0
+--  
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--  
+
+library ieee ;
+  use ieee.std_logic_1164.all ;
+  use ieee.numeric_std.all ;
+  use ieee.numeric_std_unsigned.all ;
+  use ieee.math_real.all ;
+  
+library OSVVM ; 
+  context OSVVM.OsvvmContext ; 
+  use osvvm.ScoreboardPkg_slv.all ;
+
+library OSVVM_AXI4 ;
+  context OSVVM_AXI4.Axi4Context ; 
+
+library osvvm_cosim ;
+  context osvvm_cosim.CoSimContext ;
+
+
+entity TestCtrl is
+  port (
+    -- Global Signal Interface
+    nReset            : In    std_logic ;
+
+    -- Transaction Interfaces
+    ManagerRec        : inout AddressBusRecType ;
+    SubordinateRec    : inout AddressBusRecType 
+  ) ;
+  
+  -- Derive AXI interface properties from the ManagerRec
+  constant AXI_ADDR_WIDTH : integer := ManagerRec.Address'length ; 
+  constant AXI_DATA_WIDTH : integer := ManagerRec.DataToModel'length ;  
+  constant AXI_DATA_BYTE_WIDTH : integer := AXI_DATA_WIDTH / 8 ;
+  constant AXI_BYTE_ADDR_WIDTH : integer := integer(ceil(log2(real(AXI_DATA_BYTE_WIDTH)))) ;
+    
+  -- Simplifying access to Burst FIFOs using aliases
+  alias WriteBurstFifo : ScoreboardIdType is ManagerRec.WriteBurstFifo ;
+  alias ReadBurstFifo  : ScoreboardIdType is ManagerRec.ReadBurstFifo ;
+end entity TestCtrl ;

--- a/testbench/TbAxi4_Responder/tests.pro
+++ b/testbench/TbAxi4_Responder/tests.pro
@@ -1,0 +1,49 @@
+#  File Name:               tests.pro
+#  Revision:                OSVVM MODELS STANDARD VERSION
+#
+#  Maintainer:              Simon Southwell      simon.southwell@gmail.com
+#  Contributor(s):
+#     Simon Southwell       simon.southwell@gmail.com
+#     Jim Lewis             jim@synthworks.com
+#
+#
+#  Description:
+#        Script to run Axi4 Lite CoSim tests
+#
+#  Developed for:
+#        SynthWorks Design Inc.
+#        VHDL Training Classes
+#        11898 SW 128th Ave.  Tigard, Or  97223
+#        http://www.SynthWorks.com
+#
+#  Revision History:
+#    Date      Version    Description
+#    12/2022   2023.01    Refactored to source scripts in Scripts/StartUpShared.tcl and 
+#                         analyze CoSim by calling CoSim/CoSim.pro in OsvvmLibraries/OsvvmLibraries.pro
+#     9/2022   --         Initial version
+#
+#
+#  This file is part of OSVVM.
+#
+#  Copyright (c) 2022 by [OSVVM Authors](../../AUTHORS.md)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+library    osvvm_CoSim_TbAxi4
+
+ChangeWorkingDirectory ../../tests
+
+MkVproc    responder
+TestName   CoSim_responder
+simulate   TbAb_Responder [CoSim]

--- a/testbench/TbDpRam/TbDpRam.pro
+++ b/testbench/TbDpRam/TbDpRam.pro
@@ -1,0 +1,45 @@
+#  File Name:         TbAxi4.pro
+#  Revision:          STANDARD VERSION
+#
+#  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+#  Contributor(s):
+#     Jim Lewis      jim@synthworks.com
+#
+#
+#  Description:
+#        Script to analyze Axi4 testbench  
+#
+#  Developed for:
+#        SynthWorks Design Inc.
+#        VHDL Training Classes
+#        11898 SW 128th Ave.  Tigard, Or  97223
+#        http://www.SynthWorks.com
+#
+#  Revision History:
+#    Date      Version    Description
+#    05/2023   2023.05    Compile Script for OSVVM
+#
+#
+#  This file is part of OSVVM.
+#  
+#  Copyright (c) 2023 by SynthWorks Design Inc.  
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+TestSuite  CoSim_TbDpRam
+library    osvvm_CoSim_TbDpRam
+analyze    TestCtrl_e.vhd
+
+analyze    TbDpRam.vhd 
+analyze    ../TestCases_DpRam/TbDpRam_WriteAndRead.vhd
+

--- a/testbench/TbDpRam/TbDpRam.vhd
+++ b/testbench/TbDpRam/TbDpRam.vhd
@@ -1,0 +1,184 @@
+--
+--  File Name:         TbDpRam.vhd
+--  Design Unit Name:  TbDpRam
+--  Revision:          OSVVM MODELS STANDARD VERSION
+--
+--  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+--  Contributor(s):
+--     Jim Lewis      jim@synthworks.com
+--
+--
+--  Description:
+--      Simple AXI Lite Manager Model
+--
+--
+--  Developed by:
+--        SynthWorks Design Inc.
+--        VHDL Training Classes
+--        http://www.SynthWorks.com
+--
+--  Revision History:
+--    Date      Version    Description
+--    04/2018   2018       Initial revision
+--    01/2020   2020.01    Updated license notice
+--    12/2020   2020.12    Updated signal and port names
+--
+--
+--  This file is part of OSVVM.
+--
+--  Copyright (c) 2018 - 2020 by SynthWorks Design Inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+
+library ieee ;
+  use ieee.std_logic_1164.all ;
+  use ieee.numeric_std.all ;
+  use ieee.numeric_std_unsigned.all ;
+
+library osvvm ;
+  context osvvm.OsvvmContext ;
+
+library OSVVM_DPRAM ;
+  context OSVVM_DpRam.DPRamContext ; 
+
+entity TbDpRam is
+end entity TbDpRam ;
+architecture TestHarness of TbDpRam is
+  constant ADDR_WIDTH : integer := 24 ;
+  constant DATA_WIDTH : integer := 16 ;
+
+  constant tperiod_Clk : time := 10 ns ;
+  constant tpd         : time := 2 ns ;
+
+  signal Clk         : std_logic ;
+  signal nReset      : std_logic ;
+
+  signal AddrA      : std_logic_vector(ADDR_WIDTH-1 downto 0) ; 
+  signal WriteA     : std_logic ; 
+  signal DataInA    : std_logic_vector(DATA_WIDTH-1 downto 0) ; 
+  signal DataOutA   : std_logic_vector(DATA_WIDTH-1 downto 0) ; 
+
+  signal AddrB      : std_logic_vector(ADDR_WIDTH-1 downto 0) ; 
+  signal WriteB     : std_logic ; 
+  signal DataInB    : std_logic_vector(DATA_WIDTH-1 downto 0) ; 
+  signal DataOutB   : std_logic_vector(DATA_WIDTH-1 downto 0) ; 
+
+  signal Manager1Rec, Manager2Rec  : AddressBusRecType (
+          Address(ADDR_WIDTH-1 downto 0),
+          DataToModel(DATA_WIDTH-1 downto 0),
+          DataFromModel(DATA_WIDTH-1 downto 0)
+        ) ;
+
+  component TestCtrl is
+    port (
+      -- Global Signal Interface
+      nReset         : In    std_logic ;
+
+      -- Transaction Interfaces
+      Manager1Rec    : inout AddressBusRecType ;
+      Manager2Rec    : inout AddressBusRecType
+    ) ;
+  end component TestCtrl ;
+
+begin
+
+  -- create Clock
+  Osvvm.TbUtilPkg.CreateClock (
+    Clk        => Clk,
+    Period     => Tperiod_Clk
+  )  ;
+
+  -- create nReset
+  Osvvm.TbUtilPkg.CreateReset (
+    Reset       => nReset,
+    ResetActive => '0',
+    Clk         => Clk,
+    Period      => 7 * tperiod_Clk,
+    tpd         => tpd
+  ) ;
+
+  ------------------------------------------------------------
+   DpRam_1 : DpRam
+  ------------------------------------------------------------
+    generic map ( 
+      ADDR_WIDTH   => ADDR_WIDTH,
+      DATA_WIDTH   => DATA_WIDTH,
+      REGA_OUT     => FALSE, 
+      REGB_OUT     => FALSE,
+      MEMORY_NAME  => "DpRam_1"
+    )
+    port map (
+      ClkA         => Clk     ,
+      AddrA        => AddrA   ,
+      WriteA       => WriteA  ,
+      DataInA      => DataInA ,
+      DataOutA     => DataOutA,
+      
+      ClkB         => Clk     ,
+      AddrB        => AddrB   ,
+      WriteB       => WriteB  ,
+      DataInB      => DataInB ,
+      DataOutB     => DataOutB
+    ) ; 
+
+
+
+  ------------------------------------------------------------
+  DpRamController_1 : DpRamController 
+  ------------------------------------------------------------
+  port map (
+    -- Globals
+    Clk         => Clk   ,
+    nReset      => nReset,
+
+    -- AXI Manager Functional Interface
+    Address     => AddrA   , 
+    Write       => WriteA  , 
+    oData       => DataInA , 
+    iData       => DataOutA, 
+
+    -- Testbench Transaction Interface
+    TransRec    => Manager1Rec 
+  ) ;
+  
+  ------------------------------------------------------------
+  DpRamController_2 : DpRamController 
+  ------------------------------------------------------------
+  port map (
+    -- Globals
+    Clk         => Clk   ,
+    nReset      => nReset,
+
+    -- AXI Manager Functional Interface
+    Address     => AddrB   , 
+    Write       => WriteB  , 
+    oData       => DataInB , 
+    iData       => DataOutB, 
+
+    -- Testbench Transaction Interface
+    TransRec    =>  Manager2Rec
+  ) ;
+  
+  
+  TestCtrl_1 : TestCtrl
+  port map (
+    -- Global Signal Interface
+    nReset        => nReset,
+
+    -- Transaction Interfaces
+    Manager1Rec   => Manager1Rec,
+    Manager2Rec   => Manager2Rec
+  ) ;
+
+end architecture TestHarness ;

--- a/testbench/TbDpRam/TestCtrl_e.vhd
+++ b/testbench/TbDpRam/TestCtrl_e.vhd
@@ -1,0 +1,72 @@
+--
+--  File Name:         TestCtrl_e.vhd
+--  Design Unit Name:  TestCtrl
+--  Revision:          OSVVM MODELS STANDARD VERSION
+--
+--  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+--  Contributor(s):
+--     Jim Lewis      jim@synthworks.com
+--
+--
+--  Description:
+--      Test transaction source
+--
+--
+--  Developed by:
+--        SynthWorks Design Inc.
+--        VHDL Training Classes
+--        http://www.SynthWorks.com
+--
+--  Revision History:
+--    Date      Version    Description
+--    05/2023   2017.09    Initial revision
+--
+--
+--  This file is part of OSVVM.
+--  
+--  Copyright (c) 2023 by SynthWorks Design Inc.  
+--  
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--  
+--      https://www.apache.org/licenses/LICENSE-2.0
+--  
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--  
+
+library ieee ;
+  use ieee.std_logic_1164.all ;
+  use ieee.numeric_std.all ;
+  use ieee.numeric_std_unsigned.all ;
+  use ieee.math_real.all ;
+  
+library OSVVM ; 
+  context OSVVM.OsvvmContext ; 
+  use osvvm.ScoreboardPkg_slv.all ;
+
+library OSVVM_DPRAM ;
+  context OSVVM_DpRam.DPRamContext ; 
+
+library osvvm_cosim ;
+  context osvvm_cosim.CoSimContext ;
+
+-- use work.OsvvmTestCommonPkg.all ;
+
+entity TestCtrl is
+  port (
+    -- Global Signal Interface
+    nReset         : In    std_logic ;
+
+    -- Transaction Interfaces
+    Manager1Rec      : inout AddressBusRecType ;
+    Manager2Rec      : inout AddressBusRecType 
+  ) ;
+  
+  constant ADDR_WIDTH : integer := Manager1Rec.Address'length ; 
+  constant DATA_WIDTH : integer := Manager1Rec.DataToModel'length ;  
+end entity TestCtrl ;

--- a/testbench/TbDpRam/tests.pro
+++ b/testbench/TbDpRam/tests.pro
@@ -1,0 +1,49 @@
+#  File Name:               tests.pro
+#  Revision:                OSVVM MODELS STANDARD VERSION
+#
+#  Maintainer:              Simon Southwell      simon.southwell@gmail.com
+#  Contributor(s):
+#     Simon Southwell       simon.southwell@gmail.com
+#     Jim Lewis             jim@synthworks.com
+#
+#
+#  Description:
+#        Script to run Axi4 Lite CoSim tests
+#
+#  Developed for:
+#        SynthWorks Design Inc.
+#        VHDL Training Classes
+#        11898 SW 128th Ave.  Tigard, Or  97223
+#        http://www.SynthWorks.com
+#
+#  Revision History:
+#    Date      Version    Description
+#    12/2022   2023.01    Refactored to source scripts in Scripts/StartUpShared.tcl and 
+#                         analyze CoSim by calling CoSim/CoSim.pro in OsvvmLibraries/OsvvmLibraries.pro
+#     9/2022   --         Initial version
+#
+#
+#  This file is part of OSVVM.
+#
+#  Copyright (c) 2022 by [OSVVM Authors](../../AUTHORS.md)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+library    osvvm_CoSim_TbDpRam
+
+ChangeWorkingDirectory ../../tests
+
+MkVproc    writeandread
+TestName   CoSim_writeandread
+simulate   TbDpRam [CoSim]

--- a/testbench/TestCases/TbAb_CoSim.vhd
+++ b/testbench/TestCases/TbAb_CoSim.vhd
@@ -41,10 +41,10 @@
 
 architecture CoSim of TestCtrl is
 
---  constant BURST_MODE     : AddressBusFifoBurstModeType := ADDRESS_BUS_BURST_WORD_MODE ;   
+--  constant BURST_MODE     : AddressBusFifoBurstModeType := ADDRESS_BUS_BURST_WORD_MODE ;
   constant BURST_MODE     : AddressBusFifoBurstModeType := ADDRESS_BUS_BURST_BYTE_MODE ;
   constant Node           : integer         := 0 ;
-    
+
   signal   TestDone       : integer_barrier := 1 ;
   signal   TestActive     : boolean         := TRUE ;
   signal   OperationCount : integer         := 0 ;
@@ -102,6 +102,8 @@ begin
     variable Error          : integer := 0 ;
     variable IntReq         : integer := 0 ;
     variable NodeNum        : integer := Node ;
+
+    variable Count          : integer ;
   begin
     -- Initialize Randomization Objects
     OpRV.InitSeed(OpRv'instance_name) ;
@@ -127,7 +129,7 @@ begin
 
       -- Call CoSimTrans procedure to generate an access from the running VProc program
       CoSimTrans (ManagerRec, Done, Error, IntReq, NodeNum);
-      
+
       AlertIf(Error /= 0, "CoSimTrans flagged an error") ;
 
       -- Finish when counts == 0
@@ -136,7 +138,7 @@ begin
     end loop OperationLoop ;
 
     TestActive <= FALSE ;
-    
+
     -- Allow Subordinate to catch up before signaling OperationCount (needed when WRITE_OP is last)
     -- wait for 0 ns ;  -- this is enough
     WaitForClock(ManagerRec, 2) ;

--- a/testbench/TestCases/TbAb_ReadPoll.vhd
+++ b/testbench/TestCases/TbAb_ReadPoll.vhd
@@ -1,0 +1,195 @@
+--
+--  File Name:         TbAb_InterruptCoSim2.vhd
+--  Design Unit Name:  Architecture of TestCtrl
+--  Revision:          OSVVM MODELS STANDARD VERSION
+--
+--  Maintainer:        Simon Southwell  email: simon.southwell@gmail.com
+--  Contributor(s):
+--     Simon Southwell      simon.southwell@gmail.com
+--     Jim Lewis            jim@synthworks.com
+--
+--
+--  Description:
+--      Test interrupt handling done in CoSim interface
+--
+--  Revision History:
+--    Date      Version    Description
+--    12/2022   2023.01    Updated interrupts to use global signal
+--    10/2022   ------     Initial revision
+--
+--
+--  This file is part of OSVVM.
+--
+--  Copyright (c) 2022 by [OSVVM Authors](../../AUTHORS.md)
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+
+architecture ReadPoll of TestCtrl is
+
+  signal ManagerSync1, MemorySync1, TestDone : integer_barrier := 1 ;
+
+begin
+
+  ------------------------------------------------------------
+  -- ControlProc
+  --   Set up AlertLog and wait for end of test
+  ------------------------------------------------------------
+  ControlProc : process
+  begin
+
+    -- Initialization of test
+--    SetTestName("TbAb_InterruptCoSim2") ;
+    SetLogEnable(PASSED, TRUE) ;    -- Enable PASSED logs
+    SetLogEnable(INFO, TRUE) ;    -- Enable INFO logs
+    SetLogEnable(GetAlertLogID("Memory_1"), INFO, FALSE) ;
+
+    -- Wait for testbench initialization
+    wait for 0 ns ;  wait for 0 ns ;
+    TranscriptOpen(OSVVM_OUTPUT_DIRECTORY & "TbAb_InterruptCoSim2.txt") ;
+    SetTranscriptMirror(TRUE) ;
+
+    -- Wait for Design Reset
+    wait until nReset = '1' ;
+    ClearAlerts ;
+
+    -- Wait for test to finish
+    WaitForBarrier(TestDone, 35 ms) ;
+    AlertIf(now >= 35 ms, "Test finished due to timeout") ;
+    AlertIf(GetAffirmCount < 1, "Test is not Self-Checking");
+
+
+    TranscriptClose ;
+    -- Printing differs in different simulators due to differences in process order execution
+    -- AlertIfDiff("./results/TbAb_InterruptCoSim2.txt", "../AXI4/Axi4/testbench/validated_results/TbAb_InterruptCoSim2.txt", "") ;
+
+    EndOfTestReports ;
+    std.env.stop ;
+    wait ;
+  end process ControlProc ;
+
+  ------------------------------------------------------------
+  -- ManagerProc
+  --   Generate transactions for AxiManager
+  ------------------------------------------------------------
+  ManagerProc : process
+    variable Data        : std_logic_vector(AXI_DATA_WIDTH-1 downto 0) := (others => '0') ;
+    variable Done        : integer := 0 ;
+    variable Error       : integer := 0 ;
+    variable Node        : integer := 0 ;
+    variable Int         : integer := 0 ;
+    variable WaitForClockRV : RandomPType ;
+  begin
+    wait until nReset = '1' ;
+    WaitForClock(ManagerRec, 2) ;
+
+    -- Initialise VProc code
+    CoSimInit(Node);
+    -- Fetch the SetTestName
+    CoSimTrans(ManagerRec, Done, Error, Int, Node) ;
+
+    OperationLoop : loop
+    
+      -- 20 % of the time add a no-op cycle with a delay of 1 to 5 clocks
+      if WaitForClockRV.DistInt((8, 2)) = 1 then
+        WaitForClock(ManagerRec, WaitForClockRV.RandInt(1, 5)) ;
+      end if ;
+      
+      -- Inspect interrupt state and and convert to integer
+      Int         := to_integer(signed(gIntReq)) ;
+      toggle(gVProcReadInterrupts) ; 
+
+      -- Call co-simulation procedure
+      CoSimTrans(ManagerRec, Done, Error, Int, Node) ;
+
+      -- Alter if an error
+      AlertIf(Error /= 0, "CoSimTrans flagged an error") ;
+
+      -- Finish when counts == 0
+      exit when Done /= 0;
+
+    end loop OperationLoop ;
+ 
+    -- Wait for outputs to propagate and signal TestDone
+    WaitForClock(ManagerRec, 2) ;
+    WaitForBarrier(TestDone) ;
+    wait ;
+  end process ManagerProc ;
+
+  ------------------------------------------------------------
+  -- SubordinateProc
+  --   Generate transactions for AxiSubordinate
+  ------------------------------------------------------------
+  SubordinateProc : process
+    variable Addr : std_logic_vector(AXI_ADDR_WIDTH-1 downto 0) ;
+    variable Data : std_logic_vector(AXI_DATA_WIDTH-1 downto 0) ;
+  begin
+  
+    WaitForClock(SubordinateRec, 2) ;
+    
+    -- Get a write to know program has started
+    GetWrite(SubordinateRec, Addr, Data) ;
+    
+    -- First read send non-matching bits
+    SendRead(SubordinateRec, Addr, X"0000_0001") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0002") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0004") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0008") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0010") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0020") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0040") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0080") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0100") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0200") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0400") ; 
+    SendRead(SubordinateRec, Addr, X"0000_0800") ; 
+    SendRead(SubordinateRec, Addr, X"0000_1000") ; 
+    SendRead(SubordinateRec, Addr, X"0000_2000") ; 
+    SendRead(SubordinateRec, Addr, X"0000_8000") ; 
+    
+    SendRead(SubordinateRec, Addr, X"0001_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0002_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0004_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0008_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0010_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0020_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0040_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0080_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0100_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0200_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0400_0000") ; 
+    SendRead(SubordinateRec, Addr, X"0800_0000") ; 
+    SendRead(SubordinateRec, Addr, X"1000_0000") ; 
+    SendRead(SubordinateRec, Addr, X"2000_0000") ; 
+    SendRead(SubordinateRec, Addr, X"4000_0000") ;
+    SendRead(SubordinateRec, Addr, X"8000_0000") ;
+    
+    -- Send matching bit
+    SendRead(SubordinateRec, Addr, X"0000_4000") ;
+
+    -- Wait for outputs to propagate and signal TestDone
+    WaitForClock(SubordinateRec, 2) ;
+    WaitForBarrier(TestDone) ;
+    wait ;
+  end process SubordinateProc ;
+
+
+end ReadPoll ;
+
+Configuration TbAb_ReadPoll of TbAxi4 is
+  for TestHarness
+    for TestCtrl_1 : TestCtrl
+      use entity work.TestCtrl(ReadPoll) ;
+    end for ;
+  end for ;
+end TbAb_ReadPoll ;

--- a/testbench/TestCases/TestCases.pro
+++ b/testbench/TestCases/TestCases.pro
@@ -65,3 +65,9 @@ analyze TbAb_InterruptCoSim4.vhd
 MkVproc $::osvvm::OsvvmCoSimDirectory/tests/interruptCB
 simulate TbAb_InterruptCoSim4 [generic INT_EDGE_LEVEL '1'] [CoSim]
 
+#Read polling
+#analyze TbAb_ReadPoll.vhd
+#TestName   CoSim_readpoll
+#MkVproc $::osvvm::OsvvmCoSimDirectory/tests/readpoll
+#simulate TbAb_ReadPoll [CoSim]
+

--- a/testbench/TestCases/TestCases.pro
+++ b/testbench/TestCases/TestCases.pro
@@ -17,25 +17,25 @@
 #
 #
 #  This file is part of OSVVM.
-#  
+#
 #  Copyright (c) 2022 by [OSVVM Authors](../../AUTHORS.md)
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#  
+#
 #      https://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  
+#
 
 # library and TestSuite set by higher level scripts
 
-# Uses OSVVM Interrupt Handling 
+# Uses OSVVM Interrupt Handling
 # analyze TbAb_InterruptCosim1.vhd
 # MkVproc $::osvvm::OsvvmCoSimDirectory/tests/interrupt
 # simulate TbAb_InterruptCosim1
@@ -65,9 +65,4 @@ analyze TbAb_InterruptCoSim4.vhd
 MkVproc $::osvvm::OsvvmCoSimDirectory/tests/interruptCB
 simulate TbAb_InterruptCoSim4 [generic INT_EDGE_LEVEL '1'] [CoSim]
 
-#Read polling
-#analyze TbAb_ReadPoll.vhd
-#TestName   CoSim_readpoll
-#MkVproc $::osvvm::OsvvmCoSimDirectory/tests/readpoll
-#simulate TbAb_ReadPoll [CoSim]
 

--- a/testbench/TestCases_DpRam/TbDpRam_WriteAndRead.vhd
+++ b/testbench/TestCases_DpRam/TbDpRam_WriteAndRead.vhd
@@ -1,0 +1,145 @@
+--
+--  File Name:         TbDpRam_BasicReadWrite.vhd
+--  Design Unit Name:  Architecture of TestCtrl
+--  Revision:          OSVVM MODELS STANDARD VERSION
+--
+--  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+--  Contributor(s):
+--     Jim Lewis      jim@synthworks.com
+--
+--
+--  Description:
+--      Test transaction source
+--
+--
+--  Developed by:
+--        SynthWorks Design Inc.
+--        VHDL Training Classes
+--        http://www.SynthWorks.com
+--
+--  Revision History:
+--    Date      Version    Description
+--    05/2023   2023.05    Initial revision
+--
+--
+--  This file is part of OSVVM.
+--
+--  Copyright (c) 2023 by SynthWorks Design Inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+
+architecture WriteAndRead of TestCtrl is
+
+  constant Node           : integer         := 0 ;
+
+  signal   TestDone       : integer_barrier := 1 ;
+
+begin
+
+  ------------------------------------------------------------
+  -- ControlProc
+  --   Set up AlertLog and wait for end of test
+  ------------------------------------------------------------
+  ControlProc : process
+  begin
+    -- Initialization of test
+    --SetTestName("TbDpRam_BasicReadWrite") ;
+    SetLogEnable(PASSED, TRUE) ;    -- Enable PASSED logs
+    SetLogEnable(INFO, TRUE) ;    -- Enable INFO logs
+
+    -- Wait for testbench initialization
+    wait for 0 ns ;  wait for 0 ns ;
+    TranscriptOpen(OSVVM_OUTPUT_DIRECTORY & GetTestName & ".txt") ;
+    SetTranscriptMirror(TRUE) ;
+
+    -- Wait for Design Reset
+    wait until nReset = '1' ;
+    ClearAlerts ;
+
+    -- Wait for test to finish
+    WaitForBarrier(TestDone, 35 ms) ;
+    AlertIf(now >= 35 ms, "Test finished due to timeout") ;
+    AlertIf(GetAffirmCount < 1, "Test is not Self-Checking");
+
+
+    TranscriptClose ;
+    -- Printing differs in different simulators due to differences in process order execution
+    -- AlertIfDiff("./results/TbDpRam_BasicReadWrite.txt", "../AXI4/Axi4/testbench/validated_results/TbDpRam_BasicReadWrite.txt", "") ;
+
+    EndOfTestReports ;
+    std.env.stop ;
+    wait ;
+  end process ControlProc ;
+
+  ------------------------------------------------------------
+  -- ManagerProc
+  --   Generate transactions for AxiManager
+  ------------------------------------------------------------
+  ManagerProc : process
+    variable OpRV           : RandomPType ;
+    variable WaitForClockRV : RandomPType ;
+    
+    -- CoSim variables
+    variable Done           : integer := 0 ;
+    variable Error          : integer := 0 ;
+    variable IntReq         : integer := 0 ;
+    variable NodeNum        : integer := Node ;
+    
+  begin
+
+    -- Initialize Randomization Objects
+    OpRV.InitSeed(OpRv'instance_name) ;
+    WaitForClockRV.InitSeed(WaitForClockRV'instance_name) ;
+
+    -- Initialise VProc code
+    CoSimInit(NodeNum) ;
+
+    wait until nReset = '1' ;
+    -- First Alignment to clock
+    WaitForClock(Manager1Rec, 1) ;
+
+    OperationLoop : loop
+
+      -- 20 % of the time add a no-op cycle with a delay of 1 to 5 clocks
+      if WaitForClockRV.DistInt((8, 2)) = 1 then
+        WaitForClock(Manager1Rec, WaitForClockRV.RandInt(1, 5)) ;
+      end if ;
+
+      -- Call CoSimTrans procedure to generate an access from the running VProc program
+      CoSimTrans (Manager1Rec, Done, Error, IntReq, NodeNum);
+
+      AlertIf(Error /= 0, "CoSimTrans flagged an error") ;
+
+      -- Finish when counts == 0
+      exit when Done /= 0;
+
+    end loop OperationLoop ;
+
+    WaitForBarrier(TestDone) ;
+    wait ;
+    
+  end process ManagerProc ;
+
+
+end WriteAndRead ;
+
+library OSVVM_AXI4 ;
+
+Configuration TbDpRam_WriteAndRead of TbDpRam is
+  for TestHarness
+    for TestCtrl_1 : TestCtrl
+      use entity work.TestCtrl(WriteAndRead) ;
+    end for ;
+  end for ;
+end TbDpRam_WriteAndRead ;

--- a/tests/async_trans/VUserMain0.cpp
+++ b/tests/async_trans/VUserMain0.cpp
@@ -44,7 +44,7 @@
 #include <vector>
 
 // Import VProc user API
-#include "OsvvmCosim.h"
+#include "OsvvmCosimInt.h"
 
 // I am node 0 context
 static int node  = 0;
@@ -68,7 +68,7 @@ extern "C" void VUserMain0()
 
     bool                  error = false;
     std::string test_name("CoSim_async_trans");
-    OsvvmCosim  cosim(node, test_name);
+    OsvvmCosimInt  cosim(node, test_name);
 
     uint32_t addr,   data32,  wdata32, rdata32, i;
     uint16_t data16, wdata16, rdata16;
@@ -458,22 +458,54 @@ extern "C" void VUserMain0()
             error = true;
         }
     }
-    
+
     addr   = 0xa0001940;
     wdata8 = 0xd8;
-    
+
     cosim.transBurstPushIncrement(wdata8, 64);
     cosim.transBurstWrite(addr, 64);
     cosim.transBurstRead(addr, 64);
     cosim.transBurstCheckIncrement(wdata8, 64);
-    
+
     addr   = 0xe0002834;
     wdata8 = 0x0a;
-    
+
     cosim.transBurstPushRandom(wdata8, 64);
     cosim.transBurstWrite(addr, 64);
     cosim.transBurstRead(addr, 64);
     cosim.transBurstCheckRandom(wdata8, 64);
+
+    // -------------------------------
+    // Test check data methods
+
+    addr = 0x07804720;
+
+    for (i = 0; i < 64; i++)
+    {
+        wbuf[i] = 0x48 + i*3;
+    }
+
+    cosim.transBurstWrite(addr, wbuf, 64);
+    if (cosim.transBurstReadCheckData(addr, wbuf, 64))
+    {
+        VPrint("***ERROR: data mismatch on transBurstReadCheck\n");
+        error = true;
+    }
+
+    addr = 0x17804700;
+
+    for (i = 0; i < 64; i++)
+    {
+        wbuf[i] = 0xd5 + i*3;
+    }
+
+    cosim.transBurstWrite(addr, wbuf, 64);
+    cosim.transBurstRead(addr, 64);
+    if (cosim.transBurstCheckData(wbuf, 64))
+    {
+        VPrint("***ERROR: data mismatch on transBurstReadCheck\n");
+        error = true;
+    }
 
     // -------------------------------
     // Flag to the simulation we're finished, after 10 more iterations

--- a/tests/async_trans/VUserMain0.cpp
+++ b/tests/async_trans/VUserMain0.cpp
@@ -240,16 +240,203 @@ extern "C" void VUserMain0()
     cosim.transBurstWriteIncrementAsync(addr, wdata8, 16);
     cosim.transBurstWriteIncrement(addr+16, wdata8+16, 32);
     cosim.transBurstReadCheckIncrement(addr, wdata8, 48);
-    
+
     addr   = 0x5a9607a8;
     wdata8 = 0xdf;
 
     cosim.transBurstWriteRandomAsync(addr, wdata8, 64);
     cosim.transBurstWriteRandom(addr+64, wdata8 ^ 0xff, 48);
-    
+
     cosim.transBurstReadCheckRandom(addr, wdata8, 64);
     cosim.transBurstReadCheckRandom(addr+64, wdata8 ^ 0xff, 48);
 
+    // -------------------------------
+    // Test "Try" functions for 8 bit data
+
+    addr   = 0x40007000;
+    wdata8 = 0x99;
+
+    cosim.transWrite(addr, wdata8);
+
+    bool avail = cosim.transTryReadData(&rdata8);
+
+    if (avail)
+    {
+        VPrint("***ERROR: got unexpected data available returned from transTryReadData\n");
+        error = true;
+    }
+
+    cosim.transReadAddressAsync(addr);
+
+    cosim.tick(20);
+
+    avail = cosim.transTryReadData(&rdata8);
+
+    if (!avail)
+    {
+        VPrint("***ERROR: got unexpected data unavailable returned from transTryReadData\n");
+        error = true;
+    }
+
+    if (rdata8 != wdata8)
+    {
+        VPrint("***ERROR: mismatch for transTryReadData. Got 0x%02x, exp 0x%02x\n", rdata8, wdata8);
+        error = true;
+    }
+
+    // -------------------------------
+    // Test "Try" functions for 16 bit data
+
+    addr   = 0x40008000;
+    wdata16 = 0x70da;
+
+    cosim.transWrite(addr, wdata16);
+
+    avail = cosim.transTryReadData(&rdata16);
+
+    if (avail)
+    {
+        VPrint("***ERROR: got unexpected data available returned from transTryReadData\n");
+        error = true;
+    }
+
+    cosim.transReadAddressAsync(addr);
+
+    cosim.tick(20);
+
+    avail = cosim.transTryReadData(&rdata16);
+
+    if (!avail)
+    {
+        VPrint("***ERROR: got unexpected data unavailable returned from transTryReadData\n");
+        error = true;
+    }
+
+    if (rdata16 != wdata16)
+    {
+        VPrint("***ERROR: mismatch for transTryReadData. Got 0x%04x, exp 0x%04x\n", rdata16, wdata16);
+        error = true;
+    }
+
+    // -------------------------------
+    // Test "Try" functions for 16 bit data
+
+    addr    = 0x40009000;
+    wdata32 = 0x196de310;
+
+    cosim.transWrite(addr, wdata32);
+
+    avail = cosim.transTryReadData(&rdata32);
+
+    if (avail)
+    {
+        VPrint("***ERROR: got unexpected data available returned from transTryReadData\n");
+        error = true;
+    }
+
+    cosim.transReadAddressAsync(addr);
+
+    cosim.tick(20);
+
+    avail = cosim.transTryReadData(&rdata32);
+
+    if (!avail)
+    {
+        VPrint("***ERROR: got unexpected data unavailable returned from transTryReadData\n");
+        error = true;
+    }
+
+    if (rdata32 != wdata32)
+    {
+        VPrint("***ERROR: mismatch for transTryReadData. Got 0x%04x, exp 0x%04x\n", rdata32, wdata32);
+        error = true;
+    }
+
+    // -------------------------------
+    // Test "Try and check" functions for 8 bit data
+
+    addr   = 0x4000a000;
+    wdata8 = 0x3d;
+
+    cosim.transWrite(addr, wdata8);
+
+    avail = cosim.transTryReadDataCheck(wdata8);
+
+    if (avail)
+    {
+        VPrint("***ERROR: got unexpected data available returned from transTryReadDataCheck\n");
+        error = true;
+    }
+
+    cosim.transReadAddressAsync(addr);
+
+    cosim.tick(20);
+
+    avail = cosim.transTryReadDataCheck(wdata8);
+
+    if (!avail)
+    {
+        VPrint("***ERROR: got unexpected data unavailable returned from transTryReadDataCheck\n");
+        error = true;
+    }
+
+    // -------------------------------
+    // Test "Try" functions for 16 bit data
+
+    addr    = 0x4000b000;
+    wdata16 = 0xf31a;
+
+    cosim.transWrite(addr, wdata16);
+
+    avail = cosim.transTryReadDataCheck(wdata16);
+
+    if (avail)
+    {
+        VPrint("***ERROR: got unexpected data available returned from transTryReadDataCheck\n");
+        error = true;
+    }
+
+    cosim.transReadAddressAsync(addr);
+
+    cosim.tick(20);
+
+    avail = cosim.transTryReadDataCheck(wdata16);
+
+    if (!avail)
+    {
+        VPrint("***ERROR: got unexpected data unavailable returned from transTryReadDataCheck\n");
+        error = true;
+    }
+
+    // -------------------------------
+    // Test "Try" functions for 16 bit data
+
+    addr    = 0x4000c000;
+    wdata32 = 0x9e23a007;
+
+    cosim.transWrite(addr, wdata32);
+
+    avail = cosim.transTryReadDataCheck(wdata32);
+
+    if (avail)
+    {
+        VPrint("***ERROR: got unexpected data available returned from transTryReadDataCheck\n");
+        error = true;
+    }
+
+    cosim.transReadAddressAsync(addr);
+
+    cosim.tick(20);
+
+    avail = cosim.transTryReadDataCheck(wdata32);
+
+    if (!avail)
+    {
+        VPrint("***ERROR: got unexpected data unavailable returned from transTryReadDataCheck\n");
+        error = true;
+    }
+
+    // -------------------------------
     // Flag to the simulation we're finished, after 10 more iterations
     cosim.tick(10, true, error);
 

--- a/tests/async_trans/VUserMain0.cpp
+++ b/tests/async_trans/VUserMain0.cpp
@@ -1,0 +1,275 @@
+// ------------------------------------------------------------------------------
+//
+//  File Name:           VUserMain0.cpp
+//  Design Unit Name:    Co-simulation virtual processor test program
+//  Revision:            OSVVM MODELS STANDARD VERSION
+//
+//  Maintainer:          Simon Southwell      email:  simon.southwell@gmail.com
+//  Contributor(s):
+//     Simon Southwell   simon.southwell@gmail.com
+//
+//  Description:
+//      Co-simulation test transaction source
+//
+//  Developed by:
+//        Simon Southwell
+//
+//  Revision History:
+//    Date      Version    Description
+//    05/2023   2023.05    Initial revision
+//
+//  This file is part of OSVVM.
+//
+//  Copyright (c) 2023 by Simon Southwell
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+// ------------------------------------------------------------------------------
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <vector>
+
+// Import VProc user API
+#include "OsvvmCosim.h"
+
+// I am node 0 context
+static int node  = 0;
+
+#ifdef _WIN32
+#define srandom srand
+#define random rand
+#endif
+
+// ------------------------------------------------------------------------------
+// Main entry point for node 0 virtual processor software
+//
+// VUserMainX has no calling arguments. If runtime configuration required
+// then you'll need to read in a configuration file.
+//
+// ------------------------------------------------------------------------------
+
+extern "C" void VUserMain0()
+{
+    VPrint("VUserMain%d()\n", node);
+
+    bool                  error = false;
+    std::string test_name("CoSim_async_trans");
+    OsvvmCosim  cosim(node, test_name);
+
+    uint32_t addr,   data32,  wdata32, rdata32, i;
+    uint16_t data16, wdata16, rdata16;
+    uint8_t  data8,  wdata8,  rdata8;
+
+    // -------------------------------
+    // Test asynchronous writes with 32 bit data
+
+    addr  = 0x80001000;
+    wdata32 = 0x12ff34dd;
+
+    for (i = 0; i < 3; i++)
+    {
+        cosim.transWriteAsync(addr + i*4, wdata32+i);
+    }
+
+    // Blocking write to ensure all async calls have completed
+    cosim.transWrite(addr + i*4, wdata32+i);
+
+    for (i = 0; i < 4; i++)
+    {
+        cosim.transRead(addr + i*4, &rdata32);
+
+        if (rdata32 != wdata32+i)
+        {
+            VPrint("***ERROR: mismatch for async write. Got 0x%08x, exp 0x%08x\n", rdata32, (wdata32+i));
+            error = true;
+        }
+    }
+
+    // -------------------------------
+    // Test asynchronous writes with 16 bit data
+
+    addr  = 0x80002000;
+    wdata16 = 0x95b3;
+
+    for (i = 0; i < 3; i++)
+    {
+        data16 = wdata16+(i*0x1111);
+        cosim.transWriteAsync(addr + i*2, data16);
+    }
+
+    // Blocking write to ensure all async calls have completed
+    data16 = wdata16+(i*0x1111);
+    cosim.transWrite(addr + i*2, data16);
+
+    for (i = 0; i < 4; i++)
+    {
+        cosim.transRead(addr + i*2, &rdata16);
+
+        if (rdata16 != wdata16+(i*0x1111))
+        {
+            VPrint("***ERROR: mismatch for async write. Got 0x%04x, exp 0x%04x\n", rdata16, (wdata16+(i*0x1111)));
+            error = true;
+        }
+    }
+
+    // -------------------------------
+    // Test asynchronous writes with 8 bit data
+
+    addr    = 0x80003001;
+    wdata8  = 0x17;
+
+    for (i = 0; i < 3; i++)
+    {
+        data8 = wdata8+(i*0x22);
+        cosim.transWriteAsync(addr + i, data8);
+    }
+
+    // Blocking write to ensure all async calls have completed
+    data8 = wdata8+(i*0x22);
+    cosim.transWrite(addr + i, data8);
+
+    for (i = 0; i < 4; i++)
+    {
+        cosim.transRead(addr + i, &rdata8);
+
+        if (rdata8 != wdata8+(i*0x22))
+        {
+            VPrint("***ERROR: mismatch for async write. Got 0x%02x, exp 0x%02x\n", rdata8, (wdata8+(i*0x22)));
+            error = true;
+        }
+    }
+
+    // -------------------------------
+    // Test asynchronous burst writes
+
+    uint8_t wbuf [128];
+    uint8_t rbuf [128];
+    addr = 0x80004964;
+
+    for (i = 0; i < 128; i++)
+    {
+        wbuf[i] = 0x23 + i*3;
+    }
+
+    cosim.transBurstWriteAsync(addr,    &wbuf[0],  32);
+    cosim.transBurstWriteAsync(addr+32, &wbuf[32], 32);
+    cosim.transBurstWriteAsync(addr+64, &wbuf[64], 16);
+
+    // Blocking transaction to ensure the others have completed
+    cosim.transBurstWrite     (addr+80, &wbuf[80], 48);
+
+    cosim.transBurstRead      (addr, rbuf, 128);
+
+    for (i = 0; i < 128; i++)
+    {
+        if (rbuf[i] != wbuf[i])
+        {
+            VPrint("***ERROR: mismatch for async burst write. Got 0x%02x, exp 0x%02x\n", rbuf[i], wbuf[i]);
+            error = true;
+        }
+    }
+
+    // -------------------------------
+    // Test asynchronous write address
+    // and data
+
+    addr = 0x80010000;
+    
+    cosim.transWriteDataAsync((uint32_t) 0xcafef00d);
+    cosim.transWriteDataAsync((uint16_t) 0x0bad);
+
+    cosim.transWriteAddressAsync(addr);
+    cosim.transWriteAddressAsync(addr + 4);
+    cosim.transWriteAddressAsync(addr + 6);
+    cosim.transWriteAddressAsync(addr + 8);
+    cosim.transWriteAddressAsync(addr + 9);
+    cosim.transWriteAddressAsync(addr + 10);
+    cosim.transWriteAddressAsync(addr + 11);
+
+    cosim.transWriteDataAsync((uint16_t) 0x0fab, 2);
+    cosim.transWriteDataAsync((uint8_t)  0xaa,   0);
+    cosim.transWriteDataAsync((uint8_t)  0x55,   1);
+    cosim.transWriteDataAsync((uint8_t)  0xbb,   2);
+    cosim.transWriteDataAsync((uint8_t)  0xdd,   3);
+
+    uint32_t expdata32[3] = {0xcafef00d, 0x0fab0bad, 0xddbb55aa};
+
+    for (i = 0; i < 3; i++)
+    {
+        cosim.transRead(addr + i*4, &rdata32);
+
+        if (rdata32 != expdata32[i])
+        {
+            VPrint("***ERROR: mismatch for async write address/data. Got 0x%08x, exp 0x%08x\n", rdata32, expdata32[i]);
+            error = true;
+        }
+    }
+
+    // -------------------------------
+    // Test asynchronous read address
+    // and data
+    
+    cosim.transReadAddressAsync(addr);
+    cosim.transReadAddressAsync(addr + 1);
+    cosim.transReadAddressAsync(addr + 2);
+    cosim.transReadAddressAsync(addr + 3);
+    
+    uint8_t expdata8[4] = {0x0d, 0xf0, 0xfe, 0xca};
+    
+    for(i = 0; i < 4; i++)
+    {
+        cosim.transReadData(&rdata8);
+        
+        if (rdata8 != expdata8[i])
+        {
+            VPrint("***ERROR: mismatch for async read address/data. Got 0x%02x, exp 0x%02x\n", rdata8, expdata8[i]);
+            error = true;
+        }
+    }
+    
+    cosim.transReadAddressAsync(addr + 4);
+    cosim.transReadData(&rdata32);
+    
+    if (rdata32 != expdata32[1])
+    {
+        VPrint("***ERROR: mismatch for async read address/data. Got 0x%08x, exp 0x%08x\n", rdata32, expdata32[1]);
+        error = true;
+    }
+    
+    cosim.transReadAddressAsync(addr + 8);
+    cosim.transReadAddressAsync(addr + 10);
+    
+    for (i = 0; i < 2; i++)
+    {
+        cosim.transReadData(&rdata16);
+        
+        data16 = (expdata32[2] >> (i*16)) & 0xffff;
+        
+        if (rdata16 != data16)
+        {
+            VPrint("***ERROR: mismatch for async read address/data. Got 0x%04x, exp 0x%04x\n", rdata16, data16);
+            error = true;
+        }
+    }
+
+    // Flag to the simulation we're finished, after 10 more iterations
+    cosim.tick(10, true, error);
+
+    // If ever got this far then sleep forever
+    SLEEPFOREVER;
+}
+

--- a/tests/readpoll/VUserMain0.cpp
+++ b/tests/readpoll/VUserMain0.cpp
@@ -1,0 +1,89 @@
+// ------------------------------------------------------------------------------
+//
+//  File Name:           VUserMain0.cpp
+//  Design Unit Name:    Co-simulation virtual processor test program
+//  Revision:            OSVVM MODELS STANDARD VERSION
+//
+//  Maintainer:          Simon Southwell      email:  simon.southwell@gmail.com
+//  Contributor(s):
+//     Simon Southwell   simon.southwell@gmail.com
+//
+//  Description:
+//      Co-simulation test transaction source
+//
+//  Developed by:
+//        Simon Southwell
+//
+//  Revision History:
+//    Date      Version    Description
+//    09/2022   2022       Initial revision
+//
+//  This file is part of OSVVM.
+//
+//  Copyright (c) 2022 by Simon Southwell
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+// ------------------------------------------------------------------------------
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <vector>
+
+// Import VProc user API
+#include "OsvvmCosim.h"
+
+// I am node 0 context
+static int node  = 0;
+
+// ------------------------------------------------------------------------------
+// Main entry point for node 0 virtual processor software
+//
+// VUserMainX has no calling arguments. If runtime configuration required
+// then you'll need to read in a configuration file.
+//
+// ------------------------------------------------------------------------------
+
+extern "C" void VUserMain0()
+{
+    VPrint("VUserMain0(): node=%d\n", node);
+
+    bool                  error = false;
+    std::string test_name("CoSim_readpoll");
+    OsvvmCosim  cosim(node, test_name);
+    
+    uint32_t addr   = 0x00000000;
+    uint32_t data   = 0x00000001;
+    int      bidx   = 14;
+    uint32_t expval = (1 << bidx);
+
+    cosim.transWrite(addr, data);
+    
+    cosim.transReadPoll(addr, &data, bidx, 1);
+    
+    if (data != expval)
+    {
+        VPrint("***ERROR: unexpected data value. Got 0x%08x. Exp 0x%08x\n", data, expval);
+        error = true;
+    }
+    
+    // Flag to the simulation we're finished, after 10 more iterations
+    cosim.tick(10, true, error);
+
+    // If ever got this far then sleep forever
+    SLEEPFOREVER;
+}
+

--- a/tests/responder/VUserMain0.cpp
+++ b/tests/responder/VUserMain0.cpp
@@ -1,0 +1,349 @@
+// ------------------------------------------------------------------------------
+//
+//  File Name:           VUserMain0.cpp
+//  Design Unit Name:    Co-simulation virtual processor test program
+//  Revision:            OSVVM MODELS STANDARD VERSION
+//
+//  Maintainer:          Simon Southwell      email:  simon.southwell@gmail.com
+//  Contributor(s):
+//     Simon Southwell   simon.southwell@gmail.com
+//
+//  Description:
+//      Co-simulation test transaction source
+//
+//  Developed by:
+//        Simon Southwell
+//
+//  Revision History:
+//    Date      Version    Description
+//    05/2023   2023       Initial revision
+//
+//  This file is part of OSVVM.
+//
+//  Copyright (c) 2023 by Simon Southwell
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+// ------------------------------------------------------------------------------
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <vector>
+
+// Import VProc user API
+#include "OsvvmCosim.h"
+
+// I am node 0 context
+static int node  = 0;
+
+extern int barrier;
+static int last_barrier = 0;
+
+uint32_t testvals[1024];
+int      wcount = 0;
+int      rcount = 0;
+
+// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
+
+static void waitOnBarrier(void)
+{
+    OsvvmCosim  cosim(node);
+
+    while(barrier <= last_barrier)
+    {
+        cosim.tick(1);
+    }
+
+    last_barrier = barrier;
+}
+
+// ------------------------------------------------------------------------------
+// Main entry point for node 0 virtual processor software
+//
+// VUserMainX has no calling arguments. If runtime configuration required
+// then you'll need to read in a configuration file.
+//
+// ------------------------------------------------------------------------------
+
+extern "C" void VUserMain0()
+{
+    VPrint("VUserMain%d()\n", node);
+
+    bool                  error = false;
+    std::string test_name("CoSim_responder");
+    OsvvmCosim  cosim(node, test_name);
+
+    uint32_t addr;
+    uint32_t data32;
+    uint16_t data16;
+    uint8_t  data8;
+
+    int tidx = 0;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x70004000;
+    data32 = testvals[tidx++] = 0x9a50b000;
+
+    cosim.transWrite(addr, data32); wcount++;
+
+    addr   += 0x1000; testvals[tidx++] = addr;
+    data32 += 0x123;  testvals[tidx++] = data32;
+
+    cosim.transWrite(addr, data32); wcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0xa0008000;
+    data16 = testvals[tidx++] = 0x1964;
+
+    cosim.transWrite(addr, data16); wcount++;
+
+    addr   += 0x1000; testvals[tidx++] = addr;
+    data16 += 0x123;  testvals[tidx++] = data16;
+
+    cosim.transWrite(addr, data16); wcount++;
+
+    waitOnBarrier();
+
+    addr  = testvals[tidx++] = 0x9700ade0;
+    data8 = testvals[tidx++] = 0x25;
+
+    cosim.transWrite(addr, data8); wcount++;
+
+    addr   += 0x1000; testvals[tidx++] = addr;
+    data8  += 0x12;   testvals[tidx++] = data8;
+
+    cosim.transWrite(addr, data8); wcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0xbeef9000;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transWriteAddressAsync(addr); wcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0;
+    data32 = testvals[tidx++] = 0x7800c344;
+
+    cosim.transWriteDataAsync(data32);
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x41987902;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transWriteAddressAsync(addr); wcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0;
+    data16 = testvals[tidx++] = 0xffc0;
+
+    cosim.transWriteDataAsync(data16, 2);
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x007c98d0;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transWriteAddressAsync(addr); wcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0;
+    data8  = testvals[tidx++] = 0xa6;
+
+    cosim.transWriteDataAsync(data8, 0);
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x20001000;
+    testvals[tidx++] = 0;
+    testvals[tidx++] = 0;
+    data32 = testvals[tidx++] = 0xb508de78;
+
+    cosim.transWriteAddressAsync(addr); wcount++;
+    cosim.transWriteDataAsync(data32);
+
+    addr   += 4;       testvals[tidx++] = addr;
+    testvals[tidx++] = 0;
+    testvals[tidx++] = 0;
+    data16  = 0x9250;  testvals[tidx++] = data16;
+
+    cosim.transWriteAddressAsync(addr); wcount++;
+    cosim.transWriteDataAsync(data16);
+
+    addr   += 2;   testvals[tidx++] = addr;
+    testvals[tidx++] = 0;
+    testvals[tidx++] = 0;
+    data8  = 0x78; testvals[tidx++] = data8;
+
+    cosim.transWriteAddressAsync(addr); wcount++;
+    cosim.transWriteDataAsync(data8);
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0xb9008710;
+    data32 = testvals[tidx++] = 0x00340043;
+
+    cosim.transReadCheck(addr, data32); rcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x09005eed;
+    data16 = testvals[tidx++] = 0xb13d;
+
+    cosim.transReadCheck(addr, data16); rcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x3278abba;
+    data8  = testvals[tidx++] = 0x13;
+
+    cosim.transReadCheck(addr, data8); rcount++;
+
+    addr   = testvals[tidx++] = 0xA0900400;
+    data32 = testvals[tidx++] = 0xb190ef44;
+
+    cosim.transReadCheck(addr, data32); rcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x60047d08;
+    data16 = testvals[tidx++] = 0x106f;
+
+    cosim.transReadCheck(addr, data16); rcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0xfff07904;
+    data8  = testvals[tidx++] = 0x77;
+
+    cosim.transReadCheck(addr, data8); rcount++;
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0xA0900400;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transReadAddressAsync(addr); rcount++;
+
+    addr   = testvals[tidx++] = 0;
+    data32 = testvals[tidx++] = 0xc0089508;
+
+    cosim.transReadDataCheck(data32);
+
+    waitOnBarrier();
+    addr   = testvals[tidx++] = 0x777014e8;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transReadAddressAsync(addr); rcount++;
+
+    addr   = testvals[tidx++] = 0;
+    data16 = testvals[tidx++] = 0xee61;
+
+    cosim.transReadDataCheck(data16);
+
+    waitOnBarrier();
+    addr   = testvals[tidx++] = 0x43211234;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transReadAddressAsync(addr); rcount++;
+
+    addr   = testvals[tidx++] = 0;
+    data8 = testvals[tidx++] = 0x71;
+
+    cosim.transReadDataCheck(data8);
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x0099e094;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transReadAddressAsync(addr); rcount++;
+
+    addr   = testvals[tidx++] = 0;
+    data32 = testvals[tidx++] = 0x811fe4c0;
+
+    cosim.transReadDataCheck(data32);
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0xee0039e0;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transReadAddressAsync(addr); rcount++;
+
+    addr   = testvals[tidx++] = 0;
+    data16 = testvals[tidx++] = 0xd0cc;
+
+    cosim.transReadDataCheck(data16);
+
+    waitOnBarrier();
+
+    addr   = testvals[tidx++] = 0x29001cf8;
+    data32 = testvals[tidx++] = 0;
+
+    cosim.transReadAddressAsync(addr); rcount++;
+
+    addr   = testvals[tidx++] = 0;
+    data8 = testvals[tidx++] = 0xc5;
+
+    cosim.transReadDataCheck(data8);
+    
+    waitOnBarrier();
+    cosim.tick(100);
+    
+    addr   = testvals[tidx++] = 0x99885614;
+    data32 = testvals[tidx++] = 0x5ee71190;
+    
+    cosim.transWrite(addr, data32); wcount++;
+    
+    waitOnBarrier();
+    cosim.tick(100);
+    
+    addr   = testvals[tidx++] = 0xb9e14568;
+    data32 = testvals[tidx++] = 0x1ce067d2;
+    
+    cosim.transReadCheck(addr, data32); rcount++;
+    
+    waitOnBarrier();
+    cosim.tick(100);
+    
+    addr   = testvals[tidx++] = 0x11112244;
+    data32 = testvals[tidx++] = 0x3901d6fb;
+    
+    cosim.transWrite(addr, data32); wcount++;
+    
+    waitOnBarrier();
+    cosim.tick(100);
+    
+    addr   = testvals[tidx++] = 0x22229b80;
+    data32 = testvals[tidx++] = 0xe73aa691;
+    
+    cosim.transReadCheck(addr, data32); rcount++;
+
+    // Flag to the simulation we're finished, after 10 more iterations
+    cosim.tick(10, true, error);
+
+    // If ever got this far then sleep forever
+    SLEEPFOREVER;
+}
+

--- a/tests/responder/VUserMain1.cpp
+++ b/tests/responder/VUserMain1.cpp
@@ -1,0 +1,498 @@
+// ------------------------------------------------------------------------------
+//
+//  File Name:           VUserMain0.cpp
+//  Design Unit Name:    Co-simulation virtual processor test program
+//  Revision:            OSVVM MODELS STANDARD VERSION
+//
+//  Maintainer:          Simon Southwell      email:  simon.southwell@gmail.com
+//  Contributor(s):
+//     Simon Southwell   simon.southwell@gmail.com
+//
+//  Description:
+//      Co-simulation test transaction source
+//
+//  Developed by:
+//        Simon Southwell
+//
+//  Revision History:
+//    Date      Version    Description
+//    05/2023   2022       Initial revision
+//
+//  This file is part of OSVVM.
+//
+//  Copyright (c) 2023 by Simon Southwell
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+// ------------------------------------------------------------------------------
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <vector>
+
+// Import VProc user API
+#include "OsvvmCosimResp.h"
+
+// I am node 0 context
+static int node  = 1;
+
+int barrier = 0;
+
+extern uint32_t testvals[];
+extern int      wcount;
+extern int      rcount;
+
+// ------------------------------------------------------------------------------
+// Routine to check received data and availability flag
+// ------------------------------------------------------------------------------
+
+static bool checkdata(uint32_t addr, uint32_t data, int tidx, bool avail, bool expavail, char* funcstr)
+{
+    uint32_t expaddr;
+    uint32_t expdata;
+    bool     error = false;
+
+    if (avail != expavail)
+    {
+        VPrint("***ERROR: Unexpected unavailable status from %s\n", funcstr);
+        error = true;
+    }
+    else
+    {
+        expaddr = testvals[tidx];
+        expdata = testvals[tidx+1];
+
+        if (data != expdata)
+        {
+            VPrint("***ERROR: data mismatch on %s. Got 0x%08x. Exp 0x%08x\n", funcstr, data, expdata);
+            error = true;
+        }
+        else
+        {
+            if(addr != expaddr)
+            {
+                VPrint("***ERROR: address mismatch on %s. Got 0x%08x. Exp 0x%08x\n", funcstr, addr, expaddr);
+            }
+        }
+    }
+
+    return error;
+}
+
+// ------------------------------------------------------------------------------
+// Routine to release barrier for manager code to advance. A default delay of
+// 10 ticks is addeded to allowfor the manager generated transaction to complete,
+// but this can be overidden with the delay argument.
+// ------------------------------------------------------------------------------
+
+static void releaseBarrier(int delay = 10)
+{
+    OsvvmCosimResp  sub(node);
+
+    barrier++;
+
+    if (delay > 0)
+    {
+        sub.tick(delay);
+    }
+}
+
+// ------------------------------------------------------------------------------
+// Main entry point for node 1 virtual processor software
+//
+// VUserMainX has no calling arguments. If runtime configuration required
+// then you'll need to read in a configuration file.
+//
+// ------------------------------------------------------------------------------
+
+extern "C" void VUserMain1()
+{
+    VPrint("VUserMain%d()\n", node);
+
+    bool            error = false;
+    OsvvmCosimResp  sub(node);
+
+    uint32_t addr;
+    uint8_t  data8;
+    uint16_t data16;
+    uint32_t data32;
+    uint32_t expdata;
+    uint32_t expaddr;
+    bool     avail;
+    int      tidx = 0;
+
+    // ------------------------------------
+    // Test respGetTransactionCount
+    int count1 = sub.respGetTransactionCount();
+    int count2 = sub.respGetTransactionCount();
+
+    if (count2 != count1+1)
+    {
+        VPrint("***ERROR: unexpected count from respGetTransactionCount. Got %d. Exp %d", count2, count1+1);
+        error = true;
+    }
+
+    // ------------------------------------
+    // Check GetWrite and TryGetWrite
+
+    avail = sub.respTryGetWrite(&addr, &data32);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTryGetWrite\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    avail = sub.respTryGetWrite(&addr, &data32);
+    error |= checkdata(addr, data32, tidx, avail, true, "respTryGetWrite"); tidx+=2;
+
+    sub.respGetWrite(&addr, &data32);
+    error |= checkdata(addr, data32, tidx, true, true, "respGetWrite"); tidx+=2;
+
+    avail = sub.respTryGetWrite(&addr, &data16);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTryGetWrite\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    avail = sub.respTryGetWrite(&addr, &data16);
+    error |= checkdata(addr, (uint32_t)data16, tidx, avail, true, "respTryGetWrite"); tidx+=2;
+
+    sub.respGetWrite(&addr, &data16);
+    error |= checkdata(addr, (uint32_t)data16, tidx, true, true, "respGetWrite"); tidx+=2;
+
+    avail = sub.respTryGetWrite(&addr, &data8);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTryGetWrite\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    avail = sub.respTryGetWrite(&addr, &data8);
+    error |= checkdata(addr, (uint32_t)data8, tidx, avail, true, "respTryGetWrite"); tidx+=2;
+
+    sub.respGetWrite(&addr, &data8);
+    error |= checkdata(addr, (uint32_t)data8, tidx, true, true, "respGetWrite"); tidx+=2;
+
+    // ------------------------------------
+    // test respTryGetWriteAddress
+    // respGetWriteAddress, TryGetWriteData,
+    // GetWriteData
+
+    avail = sub.respTryGetWriteAddress(&addr);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTryGetWrite\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();;
+
+    avail = sub.respTryGetWriteAddress(&addr);
+    error |= checkdata(addr, 0, tidx, avail, true, "respTryGetWriteAddress"); tidx+=2;
+
+    avail = sub.respTryGetWriteData(&data32);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTryGetWrite\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    avail = sub.respTryGetWriteData(&data32);
+    error |= checkdata(0, data32, tidx, avail, true, "respTryGetWriteData"); tidx+=2;
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    sub.respGetWriteAddress(&addr);
+    error |= checkdata(addr, 0, tidx, true, true, "respGetWriteAddress"); tidx+=2;
+
+    avail = sub.respTryGetWriteData(&data16);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTryGetWrite\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    avail = sub.respTryGetWriteData(&data16);
+    error |= checkdata(0, (uint32_t)data16, tidx, avail, true, "respTryGetWriteData"); tidx+=2;
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    sub.respGetWriteAddress(&addr);
+    error |= checkdata(addr, 0, tidx, true, true, "respGetWriteAddress"); tidx+=2;
+
+    avail = sub.respTryGetWriteData(&data8);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTryGetWrite\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    sub.respGetWriteData(&data8);
+    error |= checkdata(0, (uint32_t)data8, tidx, true, true, "respGetWriteData"); tidx+=2;
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    sub.respGetWriteAddress(&addr);
+    error |= checkdata(addr, 0, tidx, true, true, "respGetWriteAddress"); tidx+=2;
+
+    sub.respGetWriteData(&data32);
+    error |= checkdata(0, data32, tidx, true, true, "respGetWriteData"); tidx+=2;
+
+    sub.respGetWriteAddress(&addr);
+    error |= checkdata(addr, 0, tidx, true, true, "respGetWriteAddress"); tidx+=2;
+
+    sub.respGetWriteData(&data16);
+    error |= checkdata(0, (uint32_t)data16, tidx, true, true, "respGetWriteData"); tidx+=2;
+
+    sub.respGetWriteAddress(&addr);
+    error |= checkdata(addr, 0, tidx, true, true, "respGetWriteAddress"); tidx+=2;
+
+    sub.respGetWriteData(&data8);
+    error |= checkdata(0, (uint32_t)data8, tidx, true, true, "respGetWriteData"); tidx+=2;
+
+    // ------------------------------------
+    // Test SendRead, TrySendRead
+
+    avail = sub.respTrySendRead(&addr, data32);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTrySendRead\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    data32 = testvals[tidx+1];
+
+    avail = sub.respTrySendRead(&addr, data32);
+    error |= checkdata(addr, data32, tidx, avail, true, "respTrySendRead"); tidx+=2;
+
+    avail = sub.respTrySendRead(&addr, data16);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTrySendRead\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    data16 = testvals[tidx+1];
+
+    avail = sub.respTrySendRead(&addr, data16);
+    error |= checkdata(addr, data16, tidx, avail, true, "respTrySendRead"); tidx+=2;
+
+    avail = sub.respTrySendRead(&addr, data8);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTrySendRead\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    data8 = testvals[tidx+1];
+
+    avail = sub.respTrySendRead(&addr, data8);
+    error |= checkdata(addr, data8, tidx, avail, true, "respTrySendRead"); tidx+=2;
+
+    // Allow the manager to advance
+    releaseBarrier();;
+
+    data32 = testvals[tidx+1];
+
+    sub.respSendRead(&addr, data32);
+    error |= checkdata(addr, data32, tidx, avail, true, "respTrySendRead"); tidx+=2;
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    data16 = testvals[tidx+1];
+
+    sub.respSendRead(&addr, data16);
+    error |= checkdata(addr, data16, tidx, avail, true, "respTrySendRead"); tidx+=2;
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    data8 = testvals[tidx+1];
+
+    sub.respSendRead(&addr, data8);
+    error |= checkdata(addr, data8, tidx, avail, true, "respTrySendRead"); tidx+=2;
+
+    // ------------------------------------
+    // Test respGetReadAddress, respTryGetReadAddr
+    // respSendReadData, respSendReadDataAsync
+
+    avail = sub.respTryGetReadAddress(&addr);
+
+    if (avail)
+    {
+        VPrint("***ERROR: Unexpected available status from respTryGetReadAddress\n");
+        error = true;
+    }
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    avail = sub.respTryGetReadAddress(&addr);
+    error |= checkdata(addr, 0, tidx, avail, true, "respTryGetReadAddress"); tidx+=2;
+
+    data32 = testvals[tidx+1];
+    sub.respSendReadData(data32);
+    error |= checkdata(0, data32, tidx, true, true, "respSendReadData"); tidx+=2;
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    sub.respGetReadAddress(&addr);
+    error |= checkdata(addr, 0, tidx, avail, true, "respGetReadAddress"); tidx+=2;
+
+    data16 = testvals[tidx+1];
+    sub.respSendReadData(data16);
+    error |= checkdata(0, data16, tidx, true, true, "respSendReadData"); tidx+=2;
+
+    // Allow the manager to advance
+    releaseBarrier();
+
+    sub.respGetReadAddress(&addr);
+    error |= checkdata(addr, 0, tidx, avail, true, "respGetReadAddress"); tidx+=2;
+
+    data8 = testvals[tidx+1];
+    sub.respSendReadData(data8);
+    error |= checkdata(0, data8, tidx, true, true, "respSendReadData"); tidx+=2;
+
+    releaseBarrier();
+
+    avail = sub.respTryGetReadAddress(&addr);
+    error |= checkdata(addr, 0, tidx, avail, true, "respTryGetReadAddress"); tidx+=2;
+
+    data32 = testvals[tidx+1];
+    sub.respSendReadDataAsync(data32);
+    error |= checkdata(0, data32, tidx, true, true, "respSendReadDataAsync"); tidx+=2;
+
+    releaseBarrier();
+
+    avail = sub.respTryGetReadAddress(&addr);
+    error |= checkdata(addr, 0, tidx, avail, true, "respTryGetReadAddress"); tidx+=2;
+
+    data16 = testvals[tidx+1];
+    sub.respSendReadDataAsync(data16);
+    error |= checkdata(0, data16, tidx, true, true, "respSendReadDataAsync"); tidx+=2;
+
+    releaseBarrier();
+
+    avail = sub.respTryGetReadAddress(&addr);
+    error |= checkdata(addr, 0, tidx, avail, true, "respTryGetReadAddress"); tidx+=2;
+
+    data8 = testvals[tidx+1];
+    sub.respSendReadDataAsync(data8);
+    error |= checkdata(0, data8, tidx, true, true, "respSendReadDataAsync"); tidx+=2;
+
+    // ------------------------------------
+
+    releaseBarrier(0);
+    sub.respWaitForTransaction();
+
+    avail = sub.respTryGetWrite(&addr, &data32);
+    error |= checkdata(addr, data32, tidx, avail, true, "respTryGetWrite"); tidx+=2;
+
+    releaseBarrier(0);
+    sub.respWaitForTransaction();
+
+    data32 = testvals[tidx+1];
+
+    avail = sub.respTrySendRead(&addr, data32);
+    error |= checkdata(addr, data32, tidx, avail, true, "respTrySendRead"); tidx+=2;
+
+    releaseBarrier(0);
+    sub.respWaitForWriteTransaction();
+
+    avail = sub.respTryGetWrite(&addr, &data32);
+    error |= checkdata(addr, data32, tidx, avail, true, "respTryGetWrite"); tidx+=2;
+
+    releaseBarrier(0);
+    sub.respWaitForReadTransaction();
+
+    data32 = testvals[tidx+1];
+
+    avail = sub.respTrySendRead(&addr, data32);
+    error |= checkdata(addr, data32, tidx, avail, true, "respTrySendRead"); tidx+=2;
+
+    // ------------------------------------
+    // Test respGetWriteTransactionCount,
+    // respGetReadTransactionCount
+
+    sub.tick(10);
+
+    if (wcount != sub.respGetWriteTransactionCount())
+    {
+        VPrint("***ERROR: mismatch in write transaction count from respGetWriteTransactionCount. Got %d. Exp %d\n", sub.respGetWriteTransactionCount(), wcount);
+        error = true;
+    }
+
+    if (rcount != sub.respGetReadTransactionCount())
+    {
+        VPrint("***ERROR: mismatch in read transaction count from respGetReadTransactionCount. Got %d. Exp %d\n", sub.respGetReadTransactionCount(), rcount);
+        error = true;
+    }
+
+    // ------------------------------------
+    // End test
+    // ------------------------------------
+
+    // Flag to the simulation we're finished, after 10 more iterations
+    sub.tick(10, true, error);
+
+    // If ever got this far then sleep forever
+    SLEEPFOREVER;
+}
+

--- a/tests/stream_axi4/VUserMain0.cpp
+++ b/tests/stream_axi4/VUserMain0.cpp
@@ -107,6 +107,15 @@ extern "C" void VUserMain0()
         }
         axistream.streamSend(wdata + idx, param);
     }
+    
+    int txcount = axistream.streamGetTxTransactionCount();
+    int rxcount = axistream.streamGetRxTransactionCount();
+    
+    if (txcount != DATASIZE || rxcount != DATASIZE)
+    {
+        VPrint("***ERROR: unexpected transaction counts. Got tx=%d, rx=%d. Exp tx=%d rx=%d\n", txcount, rxcount, DATASIZE, DATASIZE);
+        error = true;
+    }
 
     // Get received word data and check data and status values
     for (int idx = 0; idx < DATASIZE; idx++)
@@ -438,13 +447,17 @@ extern "C" void VUserMain0()
     bufidx = 0;
 
     axistream.streamBurstSendIncrementAsync(0x57, 32);
-    axistream.streamBurstSendIncrement(0xe6, 128);
+    axistream.streamBurstSendIncrementAsync(0xe6, 128);
+    
+    axistream.streamWaitForTxTransaction();
 
     axistream.streamBurstCheckIncrement(0x57, 32);
     axistream.streamBurstCheckIncrement(0xe6, 128);
 
     axistream.streamBurstSendRandomAsync(0x9b, 64);
-    axistream.streamBurstSendRandom(0x0f, 64);
+    axistream.streamBurstSendRandomAsync(0x0f, 64);
+    
+    axistream.streamWaitForRxTransaction();
 
     axistream.streamBurstCheckRandom(0x9b, 64);
     axistream.streamBurstCheckRandom(0x0f, 64);

--- a/tests/stream_ethernet/VUserMain0.cpp
+++ b/tests/stream_ethernet/VUserMain0.cpp
@@ -55,7 +55,7 @@ static int node  = 0;
 
        uint8_t TestData0[BUF_SIZE];
 extern uint8_t TestData1[BUF_SIZE];
-static uint8_t RxData[BUF_SIZE] = {{0xcc}};
+static uint8_t RxData[BUF_SIZE];
 
 // ------------------------------------------------------------------------------
 // Checkt two data bytes

--- a/tests/stream_ethernet/VUserMain0.cpp
+++ b/tests/stream_ethernet/VUserMain0.cpp
@@ -20,7 +20,7 @@
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2023 by [OSVVM Authors](../../AUTHORS.md) 
+//  Copyright (c) 2023 by [OSVVM Authors](../../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ extern "C" void VUserMain0()
     {
         TestData0[bufidx++] = random() & 0xff;
     }
-    
+
     // reset the buffer index
     bufidx = 0;
 
@@ -125,11 +125,11 @@ extern "C" void VUserMain0()
     // Get some burst data from RX stream
     txrx.streamBurstGet(&RxData[ridx], 64);        ridx += 64;
     txrx.streamBurstGet(&RxData[ridx], 128);       ridx += 128;
-    
+
     // Send some burst of data over TX stream
     txrx.streamBurstSend(&TestData0[bufidx], 256); bufidx += 256;
     txrx.streamBurstSend(&TestData0[bufidx], 256); bufidx += 256;
-    
+
     // Get some burst data from RX stream
     txrx.streamBurstGet(&RxData[ridx], 256);       ridx += 256;
     txrx.streamBurstGet(&RxData[ridx], 256);       ridx += 256;

--- a/tests/stream_ethernet/VUserMain1.cpp
+++ b/tests/stream_ethernet/VUserMain1.cpp
@@ -55,7 +55,7 @@ static int node  = 1;
 
        uint8_t TestData1[BUF_SIZE];
 extern uint8_t TestData0[BUF_SIZE];
-static uint8_t RxData[BUF_SIZE] = {{0xcc}};
+static uint8_t RxData[BUF_SIZE];
 
 // ------------------------------------------------------------------------------
 // Use VUserMain0's checkRdata function (re-entrant)

--- a/tests/writeandread/VUserMain0.cpp
+++ b/tests/writeandread/VUserMain0.cpp
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------------------------
+//
+//  File Name:           VUserMain0.cpp
+//  Design Unit Name:    Co-simulation virtual processor test program
+//  Revision:            OSVVM MODELS STANDARD VERSION
+//
+//  Maintainer:          Simon Southwell      email:  simon.southwell@gmail.com
+//  Contributor(s):
+//     Simon Southwell   simon.southwell@gmail.com
+//
+//  Description:
+//      Co-simulation test transWriteAndRead/transWriteAndReadAsync
+//      transaction source
+//
+//  Developed by:
+//        Simon Southwell
+//
+//  Revision History:
+//    Date      Version    Description
+//    05/2023   2023.05    Initial revision
+//
+//  This file is part of OSVVM.
+//
+//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+// ------------------------------------------------------------------------------
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+
+// Import VProc user API
+#include "OsvvmCosim.h"
+
+// I am node 0 context
+static int node  = 0;
+
+// ------------------------------------------------------------------------------
+// Main entry point for node 0 virtual processor software
+//
+// VUserMainX has no calling arguments. If runtime configuration required
+// then you'll need to read in a configuration file.
+//
+// ------------------------------------------------------------------------------
+
+extern "C" void VUserMain0()
+{
+    VPrint("VUserMain%d()\n", node);
+
+    bool                  error = false;
+    std::string test_name("CoSim_writeandread");
+    OsvvmCosim  cosim(node, test_name);
+
+    uint32_t addr  = 0x00010000;
+    uint16_t data1 = 0x4e8f;
+    uint16_t data2 = 0xe01c;
+    uint16_t rdata;
+
+    // Write an initial value to target location
+    cosim.transWrite(addr, data1);
+
+    // Use transWriteAndRead to update location and fetch old value
+    cosim.transWriteAndRead(addr, data2, &rdata);
+
+    // Check the returned value is correct
+    if (rdata != data1)
+    {
+        VPrint("***ERROR: mismatch on read data from transWriteAndRead. Git 0x%04x. Exp 0x%04x\n", rdata, data1);
+        error = true;
+    }
+
+    // Check the location was updated
+    cosim.transReadCheck(addr, data2);
+    
+/*
+    // New write value
+    data1 = 0xb209;
+    
+    // Do asynchronous write-and-read
+    cosim.transWriteAndReadAsync(addr, data1);
+    
+    // Wait for a read transaction
+    cosim.transWaitForReadTransaction();
+    
+    // Check the returned read data
+    cosim.transReadDataCheck(data2);
+*/  
+
+    // Flag to the simulation we're finished, after 10 more iterations
+    cosim.tick(10, true, error);
+
+    // If ever got this far then sleep forever
+    SLEEPFOREVER;
+}
+


### PR DESCRIPTION
As a follow-up from the second webinar for ALDEC, using OSVVM co-sim as the real-world example, a customer wanted to use OSVVM and its co-sim features on Riviera-Pro running on the Linux OS. Due to lack of licence (current licence node locked to a windows machine), this wasn't supported, but by requesting, and receiving, an evaluation licence, support for Riviera-Pro is now added under Linux.

The code has had the full co-sim regression tests run for all simulators for all supported OSes, including Riviera-Pro on Linux.