### PR TITLE
Fix for NVC 64-bit integers and compiling for SIEMENS 32-bit executables

### DIFF
--- a/RunAllTests.pro
+++ b/RunAllTests.pro
@@ -61,9 +61,10 @@ include  ./testbench/TbDpRam/tests.pro
 include ./testbench/TbEthernet
 include ./testbench/TestCases_Ethernet
 
-# Analyze UART testbench and run tests on it
-include ./testbench/TbUart
-include ./testbench/TestCases_Uart
+# Doesn't do any self-checks
+# # Analyze UART testbench and run tests on it
+# include ./testbench/TbUart
+# include ./testbench/TestCases_Uart
 
 # Analyse AxiStream testbench and run tests on it
 include ./testbench/TbAxi4Stream

--- a/Scripts/MakeVproc.tcl
+++ b/Scripts/MakeVproc.tcl
@@ -42,14 +42,14 @@ namespace eval ::osvvm {
 #
 # -------------------------------------------------------------------------
 
-proc gen_lib_flags {libname} {
+proc gen_lib_flags {libname sim} {
 
   # Get the OS that we are running on
   # set osname [string tolower [exec uname]]
   set osname $::osvvm::OperatingSystemName
 
   # Select the RISC-V ISS library required
-  if {$::osvvm::ToolName ne "ModelSim" } {
+  if {$sim ne "ModelSim" } {
     if {"$osname" eq "linux"} {
       set rvlib ${libname}x64
     } else {
@@ -83,44 +83,65 @@ proc mk_vproc_common {testname libname} {
 
   # Get the OS that we are running on
   set osname $::osvvm::OperatingSystemName
+  set sim    $::osvvm::ToolName
 
   # Default of no additional vendor specific flags
   set vendorflags "DUMMY="
-  
+
   # Default to using the normal makefile
   set mkfilearg "makefile"
-  
+
   # When an ALDEC simulator ...
-  if {($::osvvm::ToolName eq "ActiveHDL") || ($::osvvm::ToolName eq "RivieraPRO") } {
+  if {($sim eq "ActiveHDL") || ($sim eq "RivieraPRO") } {
     # If ActiveHDL, the choose its own makefile
-    if {($::osvvm::ToolName eq "ActiveHDL")} {
+    if {($sim eq "ActiveHDL")} {
       set mkfilearg "makefile.avhdl"
     }
-    
+
     # Ensure the correct path to the ALDEC tools
     if {"$osname" eq "linux"} {
       set aldecpath [file normalize [info nameofexecutable]/../../..]
     } else {
       set aldecpath [file normalize [info nameofexecutable]/../..]
     }
-    
+
     set vendorflags "ALDECDIR=${aldecpath}"
+
+  # If not the remaining non-Siemens tools, determine whether the
+  # simulation is an 32- or 64-bit simulation
+  } elseif {("$sim" != "NVC") && ("$sim" != "GHDL")} {
+
+    if {"$osname" eq "linux"} {
+      # Extract executable type (32-bit or 64-bit) using "file" on executable
+      set exectype [lindex [split [exec file [info nameofexecutable]]] 2]
+
+    } else {
+      # Extract executable type (PE32 or PE32+) using "file" on executable
+      set exectype [lindex [split [exec file [info nameofexecutable]]] 1]
+    }
+
+    # If Siemens executable is 64-bit, set simulator for QuestaSim (which is
+    # also good for 64-bit ModelSim SE as well), else assume 32-bit ModelSim
+    if {("$exectype" eq "PE32+") || ("$exectype" eq "64-bit")} {
+      set sim   "QuestaSim"
+    } else {
+      set sim   "ModelSim"
+    }
   }
 
-  set flags [ gen_lib_flags ${libname} ]
-  
+  set flags [ gen_lib_flags ${libname} ${sim} ]
+
   if {$::osvvm::Supports2019Integer64Bits} {
     set flags "$flags -DVHDLINTEGER64"
   }
 
   exec make --no-print-directory -C $::osvvm::OsvvmCoSimDirectory \
             -f $mkfilearg                                         \
-            SIM=$::osvvm::ToolName                                \
+            SIM=$sim                                              \
             USRCDIR=$testname                                     \
             OPDIR=$::osvvm::CurrentSimulationDirectory            \
             USRFLAGS=${flags}                                     \
             $vendorflags
-
 }
 
 # -------------------------------------------------------------------------
@@ -216,7 +237,7 @@ proc MkVprocGhdlMain {testname {libname ""} } {
 
   exec make -f $::osvvm::OsvvmCoSimDirectory/makefile.ghdl clean
 
-  set flags [ gen_lib_flags ${libname} ]
+  set flags [ gen_lib_flags ${libname} $::osvvm::ToolName ]
 
   exec make -f $::osvvm::OsvvmCoSimDirectory/makefile.ghdl                   \
             USRFLAGS=${flags}                                                \

--- a/Scripts/MakeVproc.tcl
+++ b/Scripts/MakeVproc.tcl
@@ -12,12 +12,13 @@
 #
 #  Revision History:
 #    Date      Version    Description
+#    12/2025   ????.??    Flag for when using 64-bit integers
 #    10/2022   2023.01    Initial version
 #
 #
 #  This file is part of OSVVM.
 #
-#  Copyright (c) 2022 by [OSVVM Authors](../AUTHORS.md)
+#  Copyright (c) 2022 - 2025 by [OSVVM Authors](../AUTHORS.md)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -107,6 +108,10 @@ proc mk_vproc_common {testname libname} {
   }
 
   set flags [ gen_lib_flags ${libname} ]
+  
+  if {$::osvvm::Supports2019Integer64Bits} {
+    set flags "$flags -DVHDLINTEGER64"
+  }
 
   exec make --no-print-directory -C $::osvvm::OsvvmCoSimDirectory \
             -f $mkfilearg                                         \

--- a/code/OsvvmVSched.cpp
+++ b/code/OsvvmVSched.cpp
@@ -15,6 +15,7 @@
 //
 //  Revision History:
 //    Date      Version    Description
+//    12/2025   ????.??    More generic flag to use VHPI
 //    05/2023   2023.05    Adding support for asynchronous transactions
 //                         and address bus responder transactions
 //    03/2023   2023.04    Adding basic stream support
@@ -23,7 +24,7 @@
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2023 by [OSVVM Authors](../AUTHORS.md)
+//  Copyright (c) 2023 - 2025 by [OSVVM Authors](../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -50,7 +51,7 @@
 // Pointers to state for each node (up to VP_MAX_NODES)
 pSchedState_t ns[VP_MAX_NODES] = { NULL };
 
-#if defined(ALDEC)
+#if defined(USE_VHPI)
 
 #include <vhpi_user.h>
 #include <aldecpli.h>
@@ -153,7 +154,7 @@ static void setVhpiParams(const struct vhpiCbDataS* cb, int args[], int start_of
 VPROC_RTN_TYPE VInit (VINIT_PARAMS)
 {
 
-#if defined(ALDEC)
+#if defined(USE_VHPI)
     int node;
     int args[VINIT_NUM_ARGS];
 
@@ -212,7 +213,7 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
     int VPDataWidth_int, VPAddrWidth_int;
     int VPError_int,     VPParam_int;
 
-#if defined(ALDEC)
+#if defined(USE_VHPI)
     int  args[VTRANS_NUM_ARGS];
     int  node;
     int  Interrupt;
@@ -355,7 +356,7 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
 
     DebugVPrint("===> addr=%08x rnw=%d burst=%d ticks=%d\n", VPAddr_int, VPRw_int, VPBurstSize_int, VPTicks_int);
 
-#if !defined(ALDEC)
+#if !defined(USE_VHPI)
     // Export outputs over FLI
     *VPData           = VPDataOut_int;
     *VPDataHi         = VPDataOutHi_int;
@@ -395,7 +396,7 @@ VPROC_RTN_TYPE VTrans (VTRANS_PARAMS)
 
 VPROC_RTN_TYPE VSetBurstRdByte(VSETBURSTRDBYTE_PARAMS)
 {
-#if defined(ALDEC)
+#if defined(USE_VHPI)
     int args[VSETBURSTRDBYTE_NUM_ARGS];
 
     getVhpiParams(cb, args, VSETBURSTRDBYTE_NUM_ARGS);
@@ -416,7 +417,7 @@ VPROC_RTN_TYPE VSetBurstRdByte(VSETBURSTRDBYTE_PARAMS)
 
 VPROC_RTN_TYPE VGetBurstWrByte(VGETBURSTWRBYTE_PARAMS)
 {
-#if defined(ALDEC)
+#if defined(USE_VHPI)
     int args[VGETBURSTWRBYTE_NUM_ARGS];
 
     getVhpiParams(cb, args, VGETBURSTWRBYTE_NUM_ARGS);

--- a/code/OsvvmVSchedPli.h
+++ b/code/OsvvmVSchedPli.h
@@ -15,13 +15,14 @@
 //
 //  Revision History:
 //    Date      Version    Description
+//    12/2025   ????.??    Using 64-bit arguments when flagged to do so
 //    05/2023   2023.05    Refactored VTrans arguments
 //    10/2022   2023.01    Initial revision
 //
 //
 //  This file is part of OSVVM.
 //
-//  Copyright (c) 2022-2023 by [OSVVM Authors](../AUTHORS.md)
+//  Copyright (c) 2022 - 2025 by [OSVVM Authors](../AUTHORS.md)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -38,6 +39,7 @@
 // =========================================================================
 
 #include <string.h>
+#include <stdint.h>
 
 #ifndef _OSVVM_VSCHED_PLI_H_
 #define _OSVVM_VSCHED_PLI_H_
@@ -48,23 +50,36 @@
 #define LINKAGE
 #endif
 
-#ifndef ALDEC
+#if defined(ALDEC)
+#define USE_VHPI
+#endif
 
-#define VINIT_PARAMS               int  node
-#define VTRANS_PARAMS              int  node,     int  Interrupt,   int  VPStatus,    int  VPCount,     int  VPCountSec,  \
-                                   int* VPData,   int* VPDataHi,    int* VPDataWidth,                                     \
-                                   int* VPAddr,   int* VPAddrHi,    int* VPAddrWidth,                                     \
-                                   int* VPOp,     int* VPBurstSize, int* VPTicks,     int* VPDone,      int* VPError,     \
-                                   int* VPParam
-#define VGETBURSTWRBYTE_PARAMS     int  node,     int  idx,         int* data
-#define VSETBURSTRDBYTE_PARAMS     int  node,     int  idx,         int  data
+#if !defined(USE_VHPI)
+
+# ifdef VHDLINTEGER64
+# define vint_t int64_t
+# else
+# define vint_t int32_t
+# endif
+
+#define VINIT_PARAMS               vint_t  node
+#define VTRANS_PARAMS              vint_t  node,     vint_t  Interrupt,   vint_t  VPStatus,    vint_t  VPCount,     vint_t  VPCountSec,  \
+                                   vint_t* VPData,   vint_t* VPDataHi,    vint_t* VPDataWidth,                                           \
+                                   vint_t* VPAddr,   vint_t* VPAddrHi,    vint_t* VPAddrWidth,                                           \
+                                   vint_t* VPOp,     vint_t* VPBurstSize, vint_t* VPTicks,     vint_t* VPDone,      vint_t* VPError,     \
+                                   vint_t* VPParam
+#define VGETBURSTWRBYTE_PARAMS     vint_t  node,     vint_t  idx,         vint_t* data
+#define VSETBURSTRDBYTE_PARAMS     vint_t  node,     vint_t  idx,         vint_t  data
 
 #define VPROC_RTN_TYPE             void
 
 #else
 
 #include <vhpi_user.h>
+
+#if defined(ALDEC)
 #include <aldecpli.h>
+#endif
 
 #define VINIT_PARAMS                        const struct vhpiCbDataS* cb
 #define VTRANS_PARAMS                       const struct vhpiCbDataS* cb
@@ -80,6 +95,16 @@
 #define VGETBURSTWRBYTE_START_OF_OUTPUTS    2
 
 #define VPROC_RTN_TYPE                      PLI_VOID
+
+# if defined(ALDEC)
+# define VPROC_RTN_TYPE                      PLI_VOID
+# else
+# define VPROC_RTN_TYPE                      void
+# endif
+
+# if defined(NVC)
+# define vhpiForeignT                        vhpiForeignKindT
+# endif
 
 #endif
 

--- a/makefile
+++ b/makefile
@@ -48,8 +48,8 @@
 USRCDIR            = usercode
 OPDIR              = .
 USRFLAGS           =
-SIM                = ModelSim
-ALDECDIR         =  /c/Aldec/Riviera-PRO-2025.07-x64
+SIM                =
+ALDECDIR           =  /c/Aldec/Riviera-PRO-2025.07-x64
 
 # Derived directory locations
 SRCDIR             = code
@@ -80,9 +80,7 @@ OSTYPE:=$(shell uname)
 
 TOOLFLAGS          = -m64
 
-ifeq ("${SIM}", "QuestaSim")
-  TOOLFLAGS        += -DSIEMENS
-else ifeq ("${SIM}", "RivieraPRO")
+ifeq ("${SIM}", "RivieraPRO")
   ALDECDIR         =  /c/Aldec/Riviera-PRO-2022.10-x64
   TOOLFLAGS        += -DALDEC -I${ALDECDIR}/interfaces/include
   ifeq (${OSTYPE}, Linux)
@@ -96,6 +94,8 @@ else ifeq ("${SIM}", "NVC")
   TOOLFLAGS        += -DNVC
 else ifeq ("${SIM}", "ModelSim")
   TOOLFLAGS        = -m32 -DSIEMENS
+else
+  TOOLFLAGS        += -DSIEMENS
 endif
 
 RV32EXE            = test.exe

--- a/makefile
+++ b/makefile
@@ -7,16 +7,17 @@
 #     Simon Southwell     email:  simon.southwell@gmail.com
 #
 #  Description
-#    Make file supporting compiling of Co-simuation C/C++ code
+#    Make file supporting compiling of Co-simulation C/C++ code
 #    using make
 #
 #  Revision History:
 #    Date      Version    Description
+#    12/2025   ????.??    Flagging all different supported simulators  
 #    10/2022   2023.01    Initial version
 #
 #  This file is part of OSVVM.
 #
-#  Copyright (c) 2022 by [OSVVM Authors](AUTHORS.md)
+#  Copyright (c) 2022 - 2025 by [OSVVM Authors](AUTHORS.md)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -48,6 +49,7 @@ USRCDIR            = usercode
 OPDIR              = .
 USRFLAGS           =
 SIM                = ModelSim
+ALDECDIR         =  /c/Aldec/Riviera-PRO-2025.07-x64
 
 # Derived directory locations
 SRCDIR             = code
@@ -88,6 +90,10 @@ else ifeq ("${SIM}", "RivieraPRO")
   else
     TOOLFLAGS      += -L${ALDECDIR}/interfaces/lib -l:aldecpli.lib
   endif
+else ifeq ("${SIM}", "GHDL")
+    TOOLFLAGS      += -DGHDL
+else ifeq ("${SIM}", "NVC")
+  TOOLFLAGS        += -DNVC
 else ifeq ("${SIM}", "ModelSim")
   TOOLFLAGS        = -m32 -DSIEMENS
 endif


### PR DESCRIPTION
Updated `MkVproc.tcl` to use `Supports2019Integer64Bits` to configure compile and use 64-bit types in foreign procedure C code, and to detect if SIEMENS executable is 32-bit and configure to compile foreign code as 32-bits. This applies to the ModelSim FPGA starter edition, in particular. The `makefile` is updated to default to QuestaSim by default, instead of ModelSim.

Minor updated to `OsvvmVSched.cpp` and `OsvvmVSched.h` to use a generic compile option in place of an ALDEC specific one, as a hook for updating NVC to VHPI.

UART test removed from `CoSim/RunAllTests.pro` as it does no self checking.

